### PR TITLE
update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ Pillow>=4.1.1,<4.2.0
 jupyter
 ipython
 six
-scipy<=0.17.0
 numpy<=1.11.0
+scipy<=0.17.0
 Cython
 matplotlib==2.0.2
+pythreejs


### PR DESCRIPTION
`numpy` is needed by `scipy`, so must appear before.
`pythreejs` is used in `jupyter` for the `Plot3D` command.

We could probably load `requirements.txt` in `setup.py`.
would it be a welcome addition to this PR ?