### PR TITLE
updated numpy/scipy calls to scipy 1.1

### DIFF
--- a/pyoptools/misc/pmisc/misc.py
+++ b/pyoptools/misc/pmisc/misc.py
@@ -301,8 +301,6 @@ def hitlist2int_list(x, y):
     """Function that estimates an intensity distribution on a plane from a 
     ray hitlist. Returns the intensity samples as an x,y,I list
     """
-    from pylab import meshgrid
-    from scipy import interpolate
     
     #if xi.ndim != yi.ndim:
     #    raise TypeError("inputs xi and yi must have same number of dimensions (1 or 2)")
@@ -641,7 +639,6 @@ def spot_info(C):
     return mean(R),(xm,ym),(mean(XR),mean(YR)),R.max()
 
 ####### Fin Funciones auxiliares
-
 
 
 

--- a/pyoptools/misc/pmisc/misc.py
+++ b/pyoptools/misc/pmisc/misc.py
@@ -294,7 +294,7 @@ def hitlist2int(x, y, z,  xi, yi):
     
     #Interpolacion nn, y generación de pupila
     xi,yi = meshgrid(xi,yi)
-    d1=interpolate.griddata(xc, yc, I,xi, yi )
+    d1 = interpolate.griddata(xc, yc, I, xi, yi)
     return d1
 
 def hitlist2int_list(x, y):
@@ -641,7 +641,6 @@ def spot_info(C):
     return mean(R),(xm,ym),(mean(XR),mean(YR)),R.max()
 
 ####### Fin Funciones auxiliares
-
 
 
 

--- a/pyoptools/misc/pmisc/misc.py
+++ b/pyoptools/misc/pmisc/misc.py
@@ -9,8 +9,7 @@ from numpy.ma import is_masked, MaskedArray
 from numpy.ma import array as ma_array
 
 from scipy import interpolate
-from pylab import griddata, meshgrid
-
+from pylab import meshgrid
 from matplotlib.tri import Triangulation
 
 
@@ -216,7 +215,7 @@ def hitlist2int(x, y, z,  xi, yi):
     """Function that estimates an intensity distribution on a plane from a 
     ray hitlist
     """
-    from pylab import griddata, meshgrid
+    from pylab import meshgrid
     from scipy import interpolate
     #if xi.ndim != yi.ndim:
     #    raise TypeError("inputs xi and yi must have same number of dimensions (1 or 2)")
@@ -298,14 +297,14 @@ def hitlist2int(x, y, z,  xi, yi):
     
     #Interpolacion nn, y generación de pupila
     xi,yi = meshgrid(xi,yi)
-    d1=griddata(xc, yc, I,xi, yi )
+    d1=interpolate.griddata(xc, yc, I,xi, yi )
     return d1
 
 def hitlist2int_list(x, y):
     """Function that estimates an intensity distribution on a plane from a 
     ray hitlist. Returns the intensity samples as an x,y,I list
     """
-    from pylab import griddata, meshgrid
+    from pylab import meshgrid
     from scipy import interpolate
     
     #if xi.ndim != yi.ndim:

--- a/pyoptools/misc/pmisc/misc.py
+++ b/pyoptools/misc/pmisc/misc.py
@@ -214,8 +214,6 @@ def hitlist2int(x, y, z,  xi, yi):
     """Function that estimates an intensity distribution on a plane from a 
     ray hitlist
     """
-    from pylab import meshgrid
-    from scipy import interpolate
     #if xi.ndim != yi.ndim:
     #    raise TypeError("inputs xi and yi must have same number of dimensions (1 or 2)")
     #if xi.ndim != 1 and xi.ndim != 2:
@@ -643,7 +641,6 @@ def spot_info(C):
     return mean(R),(xm,ym),(mean(XR),mean(YR)),R.max()
 
 ####### Fin Funciones auxiliares
-
 
 
 

--- a/pyoptools/misc/pmisc/misc.py
+++ b/pyoptools/misc/pmisc/misc.py
@@ -9,7 +9,6 @@ from numpy.ma import is_masked, MaskedArray
 from numpy.ma import array as ma_array
 
 from scipy import interpolate
-from pylab import meshgrid
 from matplotlib.tri import Triangulation
 
 
@@ -644,7 +643,6 @@ def spot_info(C):
     return mean(R),(xm,ym),(mean(XR),mean(YR)),R.max()
 
 ####### Fin Funciones auxiliares
-
 
 
 

--- a/pyoptools/raytrace/_comp_lib/ccd.py
+++ b/pyoptools/raytrace/_comp_lib/ccd.py
@@ -17,8 +17,6 @@
 '''
 Definition of a CCD like object and helper functions
 '''
-#Depreacated in scipy 1.0+ changed to PIL.Image.formarray
-#from scipy.misc import toimage
 from PIL.Image import fromarray
 from scipy.interpolate import interp2d,bisplrep,bisplev
 from numpy import arange, ma, meshgrid, linspace

--- a/pyoptools/raytrace/_comp_lib/ccd.py
+++ b/pyoptools/raytrace/_comp_lib/ccd.py
@@ -96,7 +96,7 @@ class CCD(Component):
             a ttribute to set the simulated resolution.
         """
         data= self.__d_surf.get_histogram(size)
-        return(fromarray(data, high=255, low=0,cmin=0,cmax=data.max()))
+        return(fromarray(data))
     
     def get_color_image(self, size=(256,256)):
         """

--- a/pyoptools/raytrace/_comp_lib/ccd.py
+++ b/pyoptools/raytrace/_comp_lib/ccd.py
@@ -17,8 +17,9 @@
 '''
 Definition of a CCD like object and helper functions
 '''
-
-from scipy.misc import toimage
+#Depreacated in scipy 1.0+ changed to PIL.Image.formarray
+#from scipy.misc import toimage
+from PIL.Image import fromarray
 from scipy.interpolate import interp2d,bisplrep,bisplev
 from numpy import arange, ma, meshgrid, linspace
 
@@ -97,7 +98,7 @@ class CCD(Component):
             a ttribute to set the simulated resolution.
         """
         data= self.__d_surf.get_histogram(size)
-        return(toimage(data, high=255, low=0,cmin=0,cmax=data.max()))
+        return(fromarray(data, high=255, low=0,cmin=0,cmax=data.max()))
     
     def get_color_image(self, size=(256,256)):
         """
@@ -108,7 +109,7 @@ class CCD(Component):
         """
         
         data= self.__d_surf.get_color_histogram(size)
-        return(toimage(data, high=255, low=0))
+        return(fromarray(data, high=255, low=0))
         
         
     #~ def im_show(self,fig=None, size=(256,256),cmap=cm.gray,title='Image',color=False):

--- a/pyoptools/raytrace/shape/rectangular.pyx
+++ b/pyoptools/raytrace/shape/rectangular.pyx
@@ -91,8 +91,8 @@ cdef class Rectangular(Shape):
         #~ 
         #~ dx,dy=self.size
         #~ nx, ny=self.samples
-        #~ Xl=linspace(-dx/2.,dx/2.,nx)
-        #~ Yl=linspace(-dy/2.,dy/2.,ny)
+        #~ Xl=linspace(-dx/2.,dx/2.,int(nx))
+        #~ Yl=linspace(-dy/2.,dy/2.,int(ny))
         #~ X, Y=meshgrid(Xl,Yl)
         #~ Z=topo(X, Y)
         #~ 
@@ -114,8 +114,8 @@ cdef class Rectangular(Shape):
         dx,dy=self.size
         nx, ny=self.samples
         ox, oy=self.offset
-        Xl=linspace(-dx/2.+ox,dx/2.+ox,nx)
-        Yl=linspace(-dy/2.+oy,dy/2.+oy,ny)
+        Xl=linspace(-dx/2.+ox,dx/2.+ox,int(nx))
+        Yl=linspace(-dy/2.+oy,dy/2.+oy,int(ny))
         X, Y=meshgrid(Xl,Yl)
         return X.ravel(),Y.ravel()
         

--- a/pyoptools/raytrace/shape/shape.pyx
+++ b/pyoptools/raytrace/shape/shape.pyx
@@ -138,8 +138,8 @@ cdef class Shape(Picklable):
             xi,xf, yi, yf =size
             
         nx, ny = ndat
-        X_M=linspace(xi, xf, nx)
-        Y_M=linspace(yi, yf, ny)
+        X_M=linspace(xi, xf, int(nx))
+        Y_M=linspace(yi, yf, int(ny))
         #X_M=arange(xi,xf*(1.+1/nx),1./nx)
         #Y_M=arange(yi,yf*(1.+1/ny),1./ny)
 

--- a/pyoptools/raytrace/surface/surface.pyx
+++ b/pyoptools/raytrace/surface/surface.pyx
@@ -37,7 +37,7 @@ from numpy.ma import array as ma_array
 
 from scipy.signal import medfilt2d
 from scipy import interpolate
-from pylab import griddata, meshgrid
+from pylab import meshgrid
 
 from inspect import getmembers, isroutine
 

--- a/pyoptools/wavefront/field/field.pyx
+++ b/pyoptools/wavefront/field/field.pyx
@@ -34,11 +34,12 @@ from numpy import dot,zeros, abs, meshgrid, pi,exp, where,angle, sqrt as npsqrt,
 
 from numpy.fft import fft2,ifft2,fftshift,ifftshift
 from numpy.ma import array as maarray,  getmask,  getmaskarray
-from matplotlib.mlab import griddata
+#deprecated use scipy.interpolate.griddata
+#from matplotlib.mlab import griddata
 
 from scipy.signal import convolve2d, fftconvolve, resample
 from scipy.integrate import simps
-from scipy.interpolate import interp2d,bisplrep,bisplev
+from scipy.interpolate import interp2d,bisplrep,bisplev, griddata
 from scipy.ndimage import map_coordinates
 from scipy.misc import imread
 

--- a/pyoptools/wavefront/field/field.pyx
+++ b/pyoptools/wavefront/field/field.pyx
@@ -41,7 +41,9 @@ from scipy.signal import convolve2d, fftconvolve, resample
 from scipy.integrate import simps
 from scipy.interpolate import interp2d,bisplrep,bisplev, griddata
 from scipy.ndimage import map_coordinates
-from scipy.misc import imread
+#depreacted in scipy 1.2.1; change to imageio
+#from scipy.misc import imread
+from imageio import imread
 
 
 #import pp

--- a/pyoptools/wavefront/zernike/zernike.py
+++ b/pyoptools/wavefront/zernike/zernike.py
@@ -8,8 +8,8 @@ import types
 try:
     from scipy import factorial, comb as binomial
 except ImportError:
-    from scipy.misc import comb as binomial
-    #moved to special in scipy1.0.0
+    #both moved to special in scipy1.0.0
+    from scipy.special import comb as binomial
     from scipy.special import factorial
 
 from numpy import mgrid, sqrt, arccos, zeros,transpose, pi, cos, sin, ones, array,\

--- a/pyoptools/wavefront/zernike/zernike.py
+++ b/pyoptools/wavefront/zernike/zernike.py
@@ -8,7 +8,9 @@ import types
 try:
     from scipy import factorial, comb as binomial
 except ImportError:
-    from scipy.misc import factorial, comb as binomial
+    from scipy.misc import comb as binomial
+    #moved to special in scipy1.0.0
+    from scipy.special import factorial
 
 from numpy import mgrid, sqrt, arccos, zeros,transpose, pi, cos, sin, ones, array,\
     where, arange


### PR DESCRIPTION
I updated a number of errors and redid calls to a bunch of deprecated numpy and scipy call. also changed the np.linspace num arg to be explicitly typecast to int in several surface files that were throwing float conversion issues due to implicitly relying on np.ceil. This is my first ever pull request, so feedback would be welcomed cause I don't know what I am doing 