### PR TITLE
Fix source comment/documentation typos

### DIFF
--- a/doc/manual.lyx
+++ b/doc/manual.lyx
@@ -1704,7 +1704,7 @@ Field Module
 \end_layout
 
 \begin_layout Standard
-The field module is used to calculate optical sistems using field propagation
+The field module is used to calculate optical systems using field propagation
  techniques.
  It defines the class field.....
 \end_layout

--- a/gls2rtgd.py
+++ b/gls2rtgd.py
@@ -39,7 +39,7 @@ except:
     exit("The input file seems not to be an OSLO glass description file")
     
 if version not in ("5.00","5.11","5.31","5.32","5.41","6.02" , "6.03"):
-    print("Library version migth not be supported. Please verify the output file")
+    print("Library version might not be supported. Please verify the output file")
 
 # Check if the output file exists
 

--- a/pyoptools/misc/Poly2D/Poly2D.pxd
+++ b/pyoptools/misc/Poly2D/Poly2D.pxd
@@ -2,7 +2,7 @@ cimport numpy as np
 
 cdef class poly2d:
     cdef public object cohef
-    # Slow lists to be used for python and for garbage colection
+    # Slow lists to be used for python and for garbage collection
     # if the slow lists are not attributes of the class they can get destroyed
     # so px_c and py_c will get erased
     cdef object px64,py64,px,py

--- a/pyoptools/misc/Poly2D/Poly2D.pyx
+++ b/pyoptools/misc/Poly2D/Poly2D.pyx
@@ -811,7 +811,7 @@ cpdef int pxpy2i(int px,int py):
     
 cpdef ord2i(o):
     """
-    Method that returns the number of coeficients of a polynomial of order o
+    Method that returns the number of coefficients of a polynomial of order o
     
     ===== == == == == == ===
     order  0  1  2  3  4 ...

--- a/pyoptools/misc/cmisc/cmisc.pyx
+++ b/pyoptools/misc/cmisc/cmisc.pyx
@@ -200,7 +200,7 @@ def unwrap(inph,in_p=(), double uv=2*np.pi, int nn =1):
         # remove the first value from the list
         cx, cy=l_un.pop(0)
     
-        # Put the coordinates of unwrapped the neigbors in the list
+        # Put the coordinates of unwrapped the neighbors in the list
         # And check for wrapping
         nv=0
         wv=0    

--- a/pyoptools/misc/pmisc/misc.py
+++ b/pyoptools/misc/pmisc/misc.py
@@ -117,7 +117,7 @@ def wavelength2RGB(wl):
     wavelength wavelength in um
 
     if the wavelength is outside the visible spectrum returns (0,0,0)
-    Original code fount at:
+    Original code found at:
     
     http://www.physics.sfasu.edu/astro/color/spectra.html
 
@@ -433,7 +433,7 @@ def unwrapv(inph,in_p=(), uv=2*pi):
         n=nonzero(nxi& nyi & nxf & nyf)
         lco=zip(XI[n], YI[n])
         
-        # Put the coordinates of unwrapped the neigbors in the list
+        # Put the coordinates of unwrapped the neighbors in the list
         
         
         # And check for wrapping
@@ -494,7 +494,7 @@ def unwrap_py(inph,in_p=(), uv=2*pi):
         # remove the first value from the list
         cx, cy=l_un.pop(0)
     
-        # Put the coordinates of unwrapped the neigbors in the list
+        # Put the coordinates of unwrapped the neighbors in the list
         # And check for wrapping
         nv=0
         wv=0    

--- a/pyoptools/paraxial/systemp.py
+++ b/pyoptools/paraxial/systemp.py
@@ -21,7 +21,7 @@ class PSurface:
         return array(((1., self.d), (0, 1)))
 
     def matrix(self, na):
-        """Return the full difraction + propagation matrix related to the
+        """Return the full diffraction + propagation matrix related to the
         surface when the previous refractive index is na
         """
         return dot(self.p_mat(), self.r_mat(na))
@@ -35,7 +35,7 @@ class PSurface:
         pass
 
     def propagate(self, ray, na):
-        """Calculates the full ray (u,v) difraction+propagation.
+        """Calculates the full ray (u,v) diffraction+propagation.
 
         Returns:
 
@@ -103,7 +103,7 @@ class PApe(PPlane):
 
     def propagate(self, ray, na):
 
-        """Calculates the full ray (u,v) difraction+propagation.
+        """Calculates the full ray (u,v) diffraction+propagation.
 
         Returns:
 
@@ -139,7 +139,7 @@ class PSystem:  # (MutableSequence):
 
     def propagate(self, ray):
 
-        """Calculates the full ray (u,v) difraction+propagation.
+        """Calculates the full ray (u,v) diffraction+propagation.
 
         Returns:
 
@@ -164,7 +164,7 @@ class PSystem:  # (MutableSequence):
 
     def get_matrix(self, ua=False):
         """Get total system matrix
-        if ua == True, stop at the firs system apperture found
+        if ua == True, stop at the firs system aperture found
         """
         na = self.surfaces[0].n
         mat = array(((1, 0), (0, 1)))

--- a/pyoptools/raytrace/_comp_lib/ccd.py
+++ b/pyoptools/raytrace/_comp_lib/ccd.py
@@ -10,7 +10,7 @@
 #
 #
 # Author:          Ricardo Amézquita Orozco
-# Description:     CCD definitión module
+# Description:     CCD definition module
 # Symbols Defined: CCD
 #------------------------------------------------------------------------------
 #
@@ -181,7 +181,7 @@ class CCD(Component):
         .. warning:: 
  
             If the rays hitting the surface are produced by more than one 
-            optical source, the returned map migth not be valid.  
+            optical source, the returned map might not be valid.  
         
         :param size: Tuple (nx,ny) containing the number of samples of the 
             returned map. The map size will be the same as the CCD
@@ -237,7 +237,7 @@ class CCD(Component):
         """Return the optical path of the rays hitting the detector.
         
         This method returns a tuple X,Y,D, containing the X,Y hit points, and 
-        D containing tha optical path data
+        D containing the optical path data
         
         .. warning::
  

--- a/pyoptools/raytrace/_comp_lib/compound_lens.py
+++ b/pyoptools/raytrace/_comp_lib/compound_lens.py
@@ -10,7 +10,7 @@
 #
 #
 # Author:          Ricardo Amézquita Orozco
-# Description:     Compount Lens definitión module
+# Description:     Compound Lens definition module
 # Symbols Defined: Doublet
 #------------------------------------------------------------------------------
 #
@@ -52,7 +52,7 @@ class Doublet(System):
                         :class:`~pyoptools.raytrace.mat_lib.material.Material` 
                         subclass instance
 
-    The origin of the cordinate system is located at the center of the doublet
+    The origin of the coordinate system is located at the center of the doublet
     in the optical axis.
     '''
     
@@ -135,7 +135,7 @@ class AirSpacedDoublet(System):
                         :class:`~pyoptools.raytrace.mat_lib.material.Material` 
                         subclass instance
 
-    The origin of the cordinate system is located at the center of the doublet
+    The origin of the coordinate system is located at the center of the doublet
     in the optical axis.
     '''
 

--- a/pyoptools/raytrace/_comp_lib/cube.py
+++ b/pyoptools/raytrace/_comp_lib/cube.py
@@ -10,7 +10,7 @@
 #
 #
 # Author:          Ricardo Amézquita Orozco
-# Description:     Beam Splitting Cube definitión module
+# Description:     Beam Splitting Cube definition module
 # Symbols Defined: BeamSplitingCube
 #------------------------------------------------------------------------------
 #
@@ -95,7 +95,7 @@ class BeamSplittingCube(System):
     :type material: float or 
        :class:`~pyoptools.raytrace.mat_lib.material.Material` subclass instance
 
-    The origin of the cordinate systema is located at the center of the cube
+    The origin of the coordinate system is located at the center of the cube
     in the optical axis (center of the hypotenuse).
     '''
 
@@ -140,7 +140,7 @@ class BeamSplitingCube(BeamSplittingCube):
     """Deprecated class, please use the one with the correct spelling
      :class:`~pyoptools.raytrace.comp_lib.BeamSplittingCube`
      
-     .. warning:: Wil be removed in the future
+     .. warning:: Will be removed in the future
 """
 
     def __init__(self, *argv, **kwargs):

--- a/pyoptools/raytrace/_comp_lib/cylindrical_lens.py
+++ b/pyoptools/raytrace/_comp_lib/cylindrical_lens.py
@@ -10,7 +10,7 @@
 #
 #
 # Author:          Ricardo Amézquita Orozco
-# Description:     Spherical lens definitión module
+# Description:     Spherical lens definition module
 # Symbols Defined: SphericalLens
 # ------------------------------------------------------------------------------
 #

--- a/pyoptools/raytrace/_comp_lib/mirror.py
+++ b/pyoptools/raytrace/_comp_lib/mirror.py
@@ -10,7 +10,7 @@
 #
 #
 # Author:          Ricardo Amézquita Orozco
-# Description:     Spherical lens definitión module
+# Description:     Spherical lens definition module
 # Symbols Defined: SphericalLens
 # ------------------------------------------------------------------------------
 #

--- a/pyoptools/raytrace/_comp_lib/powell_lens.py
+++ b/pyoptools/raytrace/_comp_lib/powell_lens.py
@@ -10,7 +10,7 @@
 #
 #
 # Author:          Ricardo Amézquita Orozco
-# Description:     Spherical lens definitión module
+# Description:     Spherical lens definition module
 # Symbols Defined: SphericalLens
 # ------------------------------------------------------------------------------
 #
@@ -34,7 +34,7 @@ class PowellLens(Component):
     *radius*
         diameter/2. of the lens in the part of the cylinder
     *thickness*
-        Thicknes of the lens measured in the center
+        Thickness of the lens measured in the center
     *Conicity K*
         Conicity of the aspherical surface
     *curvature R*
@@ -43,7 +43,7 @@ class PowellLens(Component):
         to calculate the refraction index of the lens (inherited from component)
 
 
-    The origin of the cordinate systema is located at the center of the lens
+    The origin of the coordinate system is located at the center of the lens
     in the optical axis (center between vertex).
     """
 

--- a/pyoptools/raytrace/_comp_lib/prism.py
+++ b/pyoptools/raytrace/_comp_lib/prism.py
@@ -10,7 +10,7 @@
 #
 #
 # Author:          Ricardo Amézquita Orozco
-# Description:     Prism definitión module
+# Description:     Prism definition module
 # Symbols Defined: RightAnglePrism
 #------------------------------------------------------------------------------
 #
@@ -34,7 +34,7 @@ class RightAnglePrism(Component):
         ============ ===========================================================
         width        Width of the prism face
         height       Height of the prism face
-        material     To calculate the refraction index of the prism (inerited 
+        material     To calculate the refraction index of the prism (inherited 
                      from component)
         reflectivity Reflectivity of the coating of the hipotenuse. For a normal 
                      prism it is 0. Note: Total internal reflection works in the 
@@ -45,7 +45,7 @@ class RightAnglePrism(Component):
                      it is 0.
         ============ ===========================================================
 
-    The origin of the cordinate systema is located at the center of hipotenuse
+    The origin of the coordinate system is located at the center of hipotenuse
     face of the prism
     '''
 
@@ -144,7 +144,7 @@ class DovePrism(Component):
 
     :param s: Height and depth of the dove prism
     :type s: float
-    :param l: Width of the dove prism (lenght of the longest side)
+    :param l: Width of the dove prism (length of the longest side)
     :type l: float
     :param material: Material of the prism
     :type material: float or 

--- a/pyoptools/raytrace/_comp_lib/spherical_lens.py
+++ b/pyoptools/raytrace/_comp_lib/spherical_lens.py
@@ -10,7 +10,7 @@
 #
 #
 # Author:          Ricardo Amézquita Orozco
-# Description:     Spherical lens definitión module
+# Description:     Spherical lens definition module
 # Symbols Defined: SphericalLens
 #------------------------------------------------------------------------------
 #
@@ -30,18 +30,18 @@ class SphericalLens(Component):
     **ARGUMENTS:**
         ============ ==========================================================
         radius       Aperture radious of the lens given in mm
-        thickness    Thicknes of the lens measured in the center given in mm
+        thickness    Thickness of the lens measured in the center given in mm
         curvature_s1 curvature of the anterior surface given in 1/mm
         curvature_s2 curvature of the posterior surface given in 1/mm
-        material     Used to calculate the refraction index of the lens 
-                     (inerited from component). Can be a material instance or a
+        material     Used to calculate the refraction index of the lens
+                     (inherited from component). Can be a material instance or
                      floating point number if the refraction index is constant.
         ============ ==========================================================
-    
+
     **RETURN VALUE:**
 
     Returns a Component subclass that behaves as a spherical lens. The origin of
-    the Component's cordinate systema is located at the center of the lens
+    the Component's coordinate system is located at the center of the lens
     in the optical axis (mid-point between vertex of the Spherical surfaces).
     '''
 
@@ -75,19 +75,19 @@ class SphericalLens(Component):
         self.thickness=thickness
         self.curvature_s1=curvature_s1
         self.curvature_s2=curvature_s2
-        
+
         if self.curvature_s1!=0.:
             __a_surf= Spherical (shape=Circular(radius= self.radius),
                                       curvature=self.curvature_s1)
         else:
             __a_surf= Plane(shape=Circular(radius= self.radius))
-     
+
         if self.curvature_s2!=0:
             __p_surf= Spherical (shape=Circular(radius= self.radius),
                                       curvature=self.curvature_s2)
         else:
             __p_surf= Plane(shape=Circular(radius= self.radius))
-        
+
         self.surflist["S1"]=(__a_surf,(0,0,-self.thickness/2),(0,0,0))
         self.surflist["S2"]=(__p_surf,(0,0,self.thickness/2 ),(0,0,0))
 

--- a/pyoptools/raytrace/_comp_lib/stop.py
+++ b/pyoptools/raytrace/_comp_lib/stop.py
@@ -10,7 +10,7 @@
 #
 #
 # Author:          Ricardo Amézquita Orozco
-# Description:     Prism definitión module
+# Description:     Prism definition module
 # Symbols Defined: StopC
 #------------------------------------------------------------------------------
 #

--- a/pyoptools/raytrace/calc/calc.py
+++ b/pyoptools/raytrace/calc/calc.py
@@ -111,15 +111,15 @@ def nearest_points(ray1, ray2):
     ----------
 
     r1,r2 : :class:`~pyoptools.raytrace.ray.Ray` 
-        Rays to test for intersection. 
+        Rays to test for intersection.
 
     Returns
     -------
     
     p1 : tuple(float, float, float)
-        Coordinates of the point living on the ray 1 closest to the ray 2
+        Coordinates of the point living on ray 1 closest to ray 2
     p2 : tuple(float, float, float)
-        Coordinates fo the point living on the ray 2 closest to the ray 1
+        Coordinates of the point living on ray 2 closest to ray 1
     d : float
         The distance between p1 and p2
     rv : bool
@@ -371,8 +371,8 @@ def pupil_location(opsys,ccds,opaxis):
     
     # Find the nearest points between the rays. 
     # Some times because of numerical errors, or some aberrations in the optical
-    # system, the rays do not trully intersect.
-    # Use instead the nearest points and issue a warning when the rays do not trully
+    # system, the rays do not truly intersect.
+    # Use instead the nearest points and issue a warning when the rays do not truly
     # intersect.
     
     enpl=intersection(opaxis,enp[0])[0]
@@ -407,7 +407,7 @@ def paraxial_location(opsys, opaxis):
     opsys : :class:`~pyoptools.raytrace.system.System`
         Optical system to use.
     opaxis: :class:`~pyoptools.raytrace.ray.Ray`
-        Ray representating the optical axis
+        Ray representing the optical axis
     
     Returns
     -------
@@ -504,7 +504,7 @@ def find_apperture(ccd, size=(50,50)):
     Notes
     -----
     
-    Right now only works for round appertures.
+    Right now only works for round apertures.
     
     .. todo:: 
         please be more specific
@@ -606,7 +606,7 @@ def get_optical_path_ep(opsys, opaxis, raylist, stop=None, r=None):
     Parameters
     ----------
     opsys : :class:`~pyoptools.raytrace.system.System`
-        Optical system under analisis
+        Optical system under analysis
     opaxis : :class:`pyoptools.raytrace.ray.Ray`
         Ray indicating the optical axis. The origin of the optical axis must be
         the position of the object used in the image formation. This is needed
@@ -709,7 +709,7 @@ def get_optical_path_ep(opsys, opaxis, raylist, stop=None, r=None):
 def find_reference_sphere_radius(ip, pl):
     """Find the radius os the reference sphere that best fits the input data.
     
-    This method asumes that the optical axis coincides with the z axis. This 
+    This method assumes that the optical axis coincides with the z axis. This 
     means that the center of the sphere, has coordinates (0,0,r).
     
     Parameters

--- a/pyoptools/raytrace/library/misc/zemax_import.py
+++ b/pyoptools/raytrace/library/misc/zemax_import.py
@@ -168,7 +168,7 @@ def zmx2pyoptoolsSP(libdata,key):
     if checktype(surflist,'EVENASPH'):
         return
     
-    #Don't include difractive optics
+    #Don't include diffractive optics
     if checktype(surflist,'BINARY_2'):
         return
     
@@ -353,7 +353,7 @@ def zmx2pyoptoolsSP(libdata,key):
         return pyot
   
     else:
-        # Print elements present in the library that were not processed or explicitelly excluded
+        # Print elements present in the library that were not processed or explicitly excluded
         print("***",key)
         print(description)
         print("Surfaces=",len(surflist))

--- a/pyoptools/raytrace/mat_lib/mat_eq.py
+++ b/pyoptools/raytrace/mat_lib/mat_eq.py
@@ -42,7 +42,7 @@ class Material:
         self.__nd__ = nd
         self.__vd__ = vd
 
-        # Check if the number of coeficients agrees with the dispersion
+        # Check if the number of coefficients agrees with the dispersion
         # formulas definition
 
         if cl is None:

--- a/pyoptools/raytrace/ray/ray.pyx
+++ b/pyoptools/raytrace/ray/ray.pyx
@@ -86,7 +86,7 @@ cdef class Ray:
                 If the value is None, the ray was emitted from the media 
                 and its Refraction index is taken (not from inside a 
                 component)
-    label       String used to follow the rays trough the system.
+    label       String used to follow the rays through the system.
     parent      Ray where this ray comes from (used to follow ray 
                 trajectory). 
     childs      List of rays originated by the interaction of this ray 
@@ -110,7 +110,7 @@ cdef class Ray:
     #~ # the ray was emitted from the media (not from inside a component)
     #~ n=Trait(None,None,Float)
     #~
-    #~ # Label to follow the rays trough the system. This attribute propagates with
+    #~ # Label to follow the rays through the system. This attribute propagates with
     #~ # the ray trace.
     #~ label=String("")
     #~ 
@@ -219,7 +219,7 @@ cdef class Ray:
             Transform also the coordinate system of the childs. By default (False)
             don't do it.
             
-        The rotation is made first, and then the traslation is made.
+        The rotation is made first, and then the translation is made.
         Note, this has to be checked
         '''
 
@@ -260,7 +260,7 @@ cdef class Ray:
             Transform also the coordinate system of the childs. By default (False)
             don't do it.
             
-        The rotation is made first, and then the traslation is made.
+        The rotation is made first, and then the translation is made.
         Note, this has to be checked
         '''
 
@@ -336,7 +336,7 @@ cdef class Ray:
         
         npos=dot(tm,t)        # if blas can be called directly, this can be improved
         ndir=dot(tm,self._dir) # Using tokio this tokio works a little faster, but have to see
-                              #How to install it right, or beter to do something similar using inline snd blas
+                              #How to install it right, or better to do something similar using inline snd blas
         
         #tokyo.dgemv3( tm, t, npos )
         #tokyo.dgemv3( tm, self.dir, ndir )
@@ -393,7 +393,7 @@ cdef class Ray:
             repr(self.label)+",orig_surf="+repr(self.orig_surf)+", order="+repr(self.order)+")"
 
     def add_child(self, cr):
-        '''Add childs to the current ray, and create the apropiate links
+        '''Add childs to the current ray, and create the appropiate links
         
         *cr*
             Ray to include in the child list

--- a/pyoptools/raytrace/shape/polygon.pyx
+++ b/pyoptools/raytrace/shape/polygon.pyx
@@ -159,7 +159,7 @@ cdef class Polygon(Shape):
                 #~ 
         #~ from matplotlib.delaunay import delaunay
         #~ 
-        #~ #Need to find a beter way to do this not using delaunay# or maybe to generate all using triangulations????
+        #~ #Need to find a better way to do this not using delaunay# or maybe to generate all using triangulations????
         #~ 
         #~ x=[p[0] for p in points] 
         #~ y=[p[1] for p in points]

--- a/pyoptools/raytrace/shape/triangular.pyx
+++ b/pyoptools/raytrace/shape/triangular.pyx
@@ -156,7 +156,7 @@ cdef class Triangular(Shape):
                 #~ 
         #~ from matplotlib.delaunay import delaunay
         #~ 
-        #~ #Need to find a beter way to do this not using delaunay# or maybe to generate all using triangulations????
+        #~ #Need to find a better way to do this not using delaunay# or maybe to generate all using triangulations????
         #~ 
         #~ x=[p[0] for p in points] 
         #~ y=[p[1] for p in points]

--- a/pyoptools/raytrace/surface/aperture.pyx
+++ b/pyoptools/raytrace/surface/aperture.pyx
@@ -13,7 +13,7 @@
 #
 #
 # Author:          Ricardo Amézquita Orozco
-# Description:     Stops definitión module
+# Description:     Stops definition module
 # Symbols Defined: Stop, StopCircAp, StopRecAp
 #------------------------------------------------------------------------------
 

--- a/pyoptools/raytrace/surface/cylindrical.pyx
+++ b/pyoptools/raytrace/surface/cylindrical.pyx
@@ -13,7 +13,7 @@
 # 
 # 
 # Author:          Ricardo Amézquita Orozco
-# Description:     Cylindrical surface definitión module
+# Description:     Cylindrical surface definition module
 # Symbols Defined: CylindricalSurface
 #------------------------------------------------------------------------------
 #

--- a/pyoptools/raytrace/surface/detector.pyx
+++ b/pyoptools/raytrace/surface/detector.pyx
@@ -11,7 +11,7 @@
 #
 #
 # Author:          Ricardo Amézquita Orozco
-# Description:     Detector surface definitión module
+# Description:     Detector surface definition module
 # Symbols Defined: CCD
 #------------------------------------------------------------------------------
 ''' Module that defines optical detector surfaces

--- a/pyoptools/raytrace/surface/plane.pyx
+++ b/pyoptools/raytrace/surface/plane.pyx
@@ -13,7 +13,7 @@
 #
 #
 # Author:          Ricardo Amézquita Orozco
-# Description:     Plane surface definitión module
+# Description:     Plane surface definition module
 # Symbols Defined: Plane
 #------------------------------------------------------------------------------
 

--- a/pyoptools/raytrace/surface/plane_mask.pyx
+++ b/pyoptools/raytrace/surface/plane_mask.pyx
@@ -13,7 +13,7 @@
 #
 #
 # Author:          Ricardo Amézquita Orozco
-# Description:     Plane surface definitión module
+# Description:     Plane surface definition module
 # Symbols Defined: Plane
 #------------------------------------------------------------------------------
 

--- a/pyoptools/raytrace/surface/spherical.pyx
+++ b/pyoptools/raytrace/surface/spherical.pyx
@@ -11,7 +11,7 @@
 # 
 # 
 # Author:          Ricardo Amézquita Orozco
-# Description:     Spherical surface definitión module
+# Description:     Spherical surface definition module
 # Symbols Defined: Spherical
 #------------------------------------------------------------------------------
 
@@ -129,7 +129,7 @@ cdef class Spherical(Surface):
         ##o el rayo es tangente y no hay interseccion 
             
         # TODO: This can have problems if the ray is propagates in the X or Y direcction 
-        # Need to find a beter solution 
+        # Need to find a better solution 
 
         if abs(Z2)<abs(Z1):
             X,Y,Z=X2,Y2,Z2

--- a/pyoptools/raytrace/surface/surface.pyx
+++ b/pyoptools/raytrace/surface/surface.pyx
@@ -266,7 +266,7 @@ cdef class Surface(Picklable):
         
         cdef np.ndarray[np.double_t, ndim=1] PI=self.intersection(iray)
         cdef double Dist
-        # Dist is possitive if the current surface is ahead of the ray. 
+        # Dist is positive if the current surface is ahead of the ray. 
         # If the surface is behind the ray, Dist becomes negative
         # If there is no intersection, Dist becomes inf
         if isinf(PI[0]) or isinf(PI[1]) or isinf(PI[2]) :#sometrue(isinf(PI)):
@@ -309,7 +309,7 @@ cdef class Surface(Picklable):
         
         PI=self._intersection(iray)
         
-        # Dist is possitive if the current surface is ahead of the ray. 
+        # Dist is positive if the current surface is ahead of the ray. 
         # If the surface is behind the ray, Dist becomes negative
         # If there is no intersection, Dist becomes inf
         if isinf(PI[0]) or isinf(PI[1]) or isinf(PI[2]):
@@ -948,7 +948,7 @@ cdef class Surface(Picklable):
      
         Notes: 
                - The pupil is normalized to the radius of the lens
-               - This method asumes a circular shaped pupil
+               - This method assumes a circular shaped pupil
                - The phase is returned as an optical path
                - The intensity is normalized to 1
                
@@ -1046,7 +1046,7 @@ cdef class Surface(Picklable):
         for i in range(len(X)):
             points.append((X[i],Y[i],Z[i]))
 
-        #Need to find a beter way to do this not using delaunay# or maybe to generate all using triangulations????
+        #Need to find a better way to do this not using delaunay# or maybe to generate all using triangulations????
         tri=Triangulation(X,Y)
         trip=tri.triangles
         return points, trip

--- a/pyoptools/raytrace/system/system.pyx
+++ b/pyoptools/raytrace/system/system.pyx
@@ -391,7 +391,7 @@ cdef class System(Picklable):
         """
         #TODO: All surfaces, elements and subsystems should know their 
         # coordinates, so the transformations can be made a lot faster
-        # the only problem of this aproach is that the surfaces can not be
+        # the only problem of this approach is that the surfaces can not be
         # reused in a design. They must be copied to be reused. The same will
         # Happen to the components and subsystems.
         

--- a/pyoptools/wavefront/calc/gs.py
+++ b/pyoptools/wavefront/calc/gs.py
@@ -312,7 +312,7 @@ def frGS(z,target,estimate=None, iterations=20,error=None):
 
 			#Keep only the phase in the hologram plane
 			holo.data=exp(1.j*holo.angle)
-			#Apply the amplitude constain
+			#Apply the amplitude constrain
 			holo=holo*eabs
 			
 			#Calculate the new image plane
@@ -324,7 +324,7 @@ def frGS(z,target,estimate=None, iterations=20,error=None):
 			
 			d=exp(1.j*imp.angle)
 			imp=Field(data=d, psize=imp.psize, l=imp.l)
-			#Apply the amplitude constain
+			#Apply the amplitude constrain
 			imp=imp*target.abs()
 	return holo,err
 

--- a/pyoptools/wavefront/field/field.pyx
+++ b/pyoptools/wavefront/field/field.pyx
@@ -41,7 +41,7 @@ from scipy.signal import convolve2d, fftconvolve, resample
 from scipy.integrate import simps
 from scipy.interpolate import interp2d,bisplrep,bisplev, griddata
 from scipy.ndimage import map_coordinates
-#depreacted in scipy 1.2.1; change to imageio
+#deprecated in scipy 1.2.1; change to imageio
 #from scipy.misc import imread
 from imageio import imread
 

--- a/pyoptools/wavefront/psurfrep/psurfrep.pyx
+++ b/pyoptools/wavefront/psurfrep/psurfrep.pyx
@@ -46,7 +46,7 @@ class PSurf:
         
         **Notes:** 
                - The pupil is normalized to the radius of the lens
-               - This method asumes a circular shaped pupil
+               - This method assumes a circular shaped pupil
                - The phase is returned as an optical path
                - The intensity is normalized to 1
             

--- a/pyoptools/wavefront/zernike/zernike.py
+++ b/pyoptools/wavefront/zernike/zernike.py
@@ -267,7 +267,7 @@ class ZernikeXY(object):
     cohef = property(__get_cohef__, __set_cohef__, None, "Coefficient list of the zernike polynomial")
 
     def eval(self):
-        """Not impremented yet"""
+        """Not implemented yet"""
         pass
         
     def evalm(self,x,y,mask=True):


### PR DESCRIPTION
Found via `codespell -q 3 -S ./doc/_build/html -L ba,childrens,childs,mater,nd`