### PR TITLE
Adds radially symmetric aspheric surfaces and a helper method for aspheric lens components

### DIFF
--- a/pyoptools/all.py
+++ b/pyoptools/all.py
@@ -44,6 +44,7 @@ from pyoptools.misc.lsq import *
 from pyoptools.misc.pmisc import *
 from pyoptools.misc.plist import *
 from pyoptools.misc.Poly2D import *
+from pyoptools.misc.Poly1Drot import *
 from pyoptools.misc.resources import *
 
 from pyoptools.raytrace.calc import *

--- a/pyoptools/misc/Poly1Drot/Poly1Drot.pyx
+++ b/pyoptools/misc/Poly1Drot/Poly1Drot.pyx
@@ -1,0 +1,78 @@
+#cython: profile=True
+
+import numpy as np
+cimport numpy as np
+cimport cython
+
+cdef extern from "math.h":
+    double pow(double,double)
+
+cdef class poly1DrotDeriv:
+
+    #fn_selector = {
+    #    'x' : lambda x, y, r, i, a : (i+1) * a * x * r**(i-1),
+    #    'y' : lambda x, y, r, i, a : (i+1) * a * y * r**(i-1)
+    #}
+
+    cdef public object coef
+    cdef public int wrt
+
+    def __init__(self, coef, wrt):
+        self.coef = np.array(coef, dtype=np.float64)
+        if not (wrt == 0 or wrt ==1):
+            raise ValueError(wrt+' is not a valid axis for derivative, use 0 or 1 for x/y.')
+        self.wrt = wrt
+
+    cpdef double peval(self, double x, double y):
+
+        cdef double r, s, a
+        cdef int i
+
+        r = pow(x**2 + y**2, 0.5)
+        if r == 0:
+            return 0
+
+        s = 0
+        for i, a in enumerate(self.coef):
+            if self.wrt == 0:
+                s += (i+1) * a * x * r**(i-1)
+            elif self.wrt == 1:
+                s += (i+1) * a * y * r**(i-1)
+        return s
+
+    def eval(self, x, y):
+        raise NotImplementedError
+
+cdef class poly1Drot:
+
+    cdef public object coef
+
+    def __init__(self, coef):
+        self.coef = np.array(coef, dtype=np.float64)
+
+    def eval(self, x, y):
+        r = np.sqrt(x**2 + y**2)
+        s = np.zeros(np.shape(r))
+        for i, a in enumerate(self.coef):
+            s += a * r**(i)
+        return s
+
+    cpdef double peval(self, double x, double y):
+        cdef float r, s
+        cdef int i
+
+        r = pow(x**2 + y**2, 0.5)
+        s = 0
+        for i, a in enumerate(self.coef):
+            s += a * r**(i)
+        return s
+
+    def meval(self):
+        raise ValueError
+
+    def dxdy(self):
+
+        dx = poly1DrotDeriv(self.coef, 0)
+        dy = poly1DrotDeriv(self.coef, 1)
+
+        return (dx, dy)

--- a/pyoptools/misc/Poly1Drot/Poly1Drot.pyx
+++ b/pyoptools/misc/Poly1Drot/Poly1Drot.pyx
@@ -7,6 +7,9 @@ cdef extern from "math.h":
     double pow(double,double)
 
 cdef class poly1DrotDeriv:
+    """ Class defining the derivative of a rotationally symmetric 1D polynomial.
+    Generally not instantiated indivually, but as part of poly1Drot class
+    """
 
     cdef public object coef
     cdef np.float64_t *coef_c
@@ -15,6 +18,17 @@ cdef class poly1DrotDeriv:
     cdef public int wrt
 
     def __init__(self, coef, wrt):
+        """Initilizer for a rotationally symmetric 1D polynomial derivative
+
+        Paramerers
+        ----------
+        coef : tuple of float
+            All the coeffiecents starting from index 0
+        wrt: int
+            Selector for the axis to find the derivative with respect to.
+            Either 0 or 1 for the x or y axis respectively. Other values
+            will raise a ValueError.
+        """
         self.coef = np.array(coef, dtype=np.float64)
 
         self.coef_c = <np.float64_t*>np.PyArray_DATA(self.coef)
@@ -25,6 +39,16 @@ cdef class poly1DrotDeriv:
         self.wrt = wrt
 
     cpdef double peval(self, double x, double y):
+        """
+        Evaluate the derivative at the point x, y
+
+        Parameters
+        ---
+        x : float
+            x value at which to evaluate
+        y : float
+            y value at which to evaluate
+        """
 
         cdef double r, s, a
         cdef int i = 0
@@ -46,6 +70,8 @@ cdef class poly1DrotDeriv:
         raise NotImplementedError
 
 cdef class poly1Drot:
+    """ Class defining a rotationally symmetric 1D polynomial.
+    """
 
     cdef public object coef
 
@@ -53,11 +79,23 @@ cdef class poly1Drot:
     cdef int clen
 
     def __init__(self, coef):
+        """Initilizer for a rotationally symmetric 1D polynomial
+        This can be evaluated at any point x, y in the same way as a 2D
+        polynomial.
+
+        Paramerers
+        ----------
+        coef : tuple of float
+            All the coeffiecents starting from index 0
+        """
+
         self.coef = np.array(coef, dtype=np.float64)
         self.coef_c = <np.float64_t*>np.PyArray_DATA(self.coef)
         self.clen = np.uint32(len(self.coef))
 
     def eval(self, x, y):
+        """Generic numpy evaluation method for the polynomial surface value
+        """
         r = np.sqrt(x**2 + y**2)
         s = np.zeros(np.shape(r))
         for i, a in enumerate(self.coef):
@@ -65,6 +103,8 @@ cdef class poly1Drot:
         return s
 
     cpdef double peval(self, double x, double y):
+        """Cython implementation of polynomial evaluation.
+        """
         cdef double r, s, a
         cdef int i = 0
 
@@ -79,6 +119,9 @@ cdef class poly1Drot:
         raise ValueError
 
     def dxdy(self):
+        """Method to return a tuple of poly1DrotDeriv objects, for derivatives
+        along a x and y axis respectively.
+        """
 
         dx = poly1DrotDeriv(self.coef, 0)
         dy = poly1DrotDeriv(self.coef, 1)

--- a/pyoptools/misc/Poly1Drot/__init__.py
+++ b/pyoptools/misc/Poly1Drot/__init__.py
@@ -1,0 +1,5 @@
+from .Poly1Drot import (poly1Drot,
+                     poly1DrotDeriv)
+
+__all__ = ["poly1Drot",
+           "poly1DrotDeriv"]

--- a/pyoptools/raytrace/_comp_lib/aspheric_lens.py
+++ b/pyoptools/raytrace/_comp_lib/aspheric_lens.py
@@ -1,0 +1,189 @@
+'''
+Definition of a radially-symmetric aspheric lens.
+'''
+
+from numpy import pi
+
+from pyoptools.raytrace.component import Component
+from pyoptools.raytrace.surface import Aspherical, Cylinder,  Plane, Aperture
+from pyoptools.raytrace.shape import Circular
+from pyoptools.misc.Poly1Drot import poly1Drot
+
+from types import SimpleNamespace
+
+class AsphericLens(Component):
+    '''Helper class to define radially-symmetric aspherical lenses.
+
+    Both single sided and double sided aspherics are supported.
+    Lenses with a outer brim larger than the aspheric surface are supported.
+
+    Parameters
+    ----------
+
+    thickness : float
+                The total thickness in mm of the lens at the maximum
+    outer_diameter : float, optional
+                     The outer diameter of the lens in mm.
+                     If unspecified or None, will be found from the largest
+                     of either aspheric surface.
+    material : Material or float
+               Material defining the refraction index of the lens.
+               Can be a material instance or floating point number if the
+               refraction index is constant.
+    origin : str
+             Where along the optical axis to place the origin of the
+             coordinate system. By default will the the geometric center. Can
+             also be:
+               's1_max' : Point of maximum thickness on s1
+               's1_min' : Point of minimum thickness on s1
+               's2_max' : Point of maximum thickness on s2
+               's2_min' : Point of minimum thickness on s2
+               'center' : Geometric center
+             These options can be convenient for placing the origin
+             at mounting face.
+    s1 : dict
+         Radially symmetric aspheric surface definition dict
+         for the anterior surface, as described below.
+    s2 : dict, optional
+         Either None for a plano-aspheric lens or a symmetric
+         aspheric surface definition dict for the posterior
+         surface, as described below.
+
+    Surface Definitions
+    -------------------
+
+    diameter : float
+               Diameter of the aspheric surface in mm
+    roc  : float
+           Radius of curvature parameter for the surface in mm
+    k : float
+        Conic constant
+    polycoefficents : tuple of float
+                    Tuple listing the higher order aspheric coefficients
+                    The first element corresponds to index zero.
+                    Typically, the elements used in a surface description
+                    are even numbered, starting at index 4, so the first
+                    four elements are typically zero.
+    max_thickness : float, optional
+                    Maximum thickness of the surface in mm or None.
+                    If None, the maximum thickness will be found from the
+                    thickness at zero radius, however not all possible
+                    surfaces have the maximum here.
+    '''
+    def __init__(self, outer_diameter = 8.0,
+                       thickness = 3.0,
+                       material = 1.5,
+                       origin = 'center',
+                       s1 = {'diameter' : 6.0,
+                             'roc' : 3.0,
+                             'k' : -1.5,
+                             'polycoefficents' : (0,0,0,0,3e-3,0,-10e-6),
+                             'max_thickness' : None,
+                             },
+                       s2 = None,
+                       *args,
+                       **kwargs):
+        Component.__init__(self,*args,**kwargs)
+
+        self.material = material
+        self.thickness = thickness
+        self.outer_diameter = outer_diameter
+
+        # Fill defaults and put surface definitions into namespaces
+        if not 'max_thickness' in s1:
+            s1['max_thickness'] = None
+        if s2 is not None and not 'max_thickness' in s2:
+            s2['max_thickness'] = None
+
+        s1_defn = SimpleNamespace(**s1)
+        if s2 is not None:
+            s2_defn = SimpleNamespace(**s2)
+        else:
+            s2_defn = None
+        self.s1_defn, self.s2_defn = (s1_defn, s2_defn)
+
+        # Auto select outer diameter if None
+        if self.outer_diameter is None:
+            candidates = [s1_defn.diameter]
+            if s2 is not None:
+                candidates.append(s2_defn.diameter)
+            self.outer_diameter = max(candidates)
+
+        # Start side thickness calculation, surfaces will be subtracted from this
+        side_thickness = thickness
+
+        # First surface
+        s1_surf = Aspherical(shape=Circular(radius=0.5*s1_defn.diameter),
+                        Ax = 1.0/s1_defn.roc, Ay = 1.0/s1_defn.roc,
+                        Kx = s1_defn.k, Ky = s1_defn.k,
+                        poly = poly1Drot(s1_defn.polycoefficents))
+        if s1_defn.max_thickness is None:
+            s1_defn.max_thickness = s1_surf.topo(s1_defn.diameter/2.0, 0)
+        side_thickness -= s1_defn.max_thickness
+        self.surflist.append( (s1_surf, (0,0,0), (0,0,pi/2)) )
+
+        # Second surface
+        if s2_defn is None:
+            s2_surf = Plane(shape=Circular(radius=0.5*self.outer_diameter))
+        else:
+            s2_surf = Aspherical(shape=Circular(radius=0.5*s2_defn.diameter),
+                            Ax = 1.0/s2_defn.roc, Ay = 1.0/s2_defn.roc,
+                            Kx = s2_defn.k, Ky = s2_defn.k,
+                            poly = poly1Drot(s2_defn.polycoefficents))
+            if s2_defn.max_thickness is None:
+                s2_defn.max_thickness = s2_surf.topo(s2_defn.diameter/2.0, 0)
+            side_thickness -= s2_defn.max_thickness
+        self.surflist.append( (s2_surf, (0,0,thickness), (0,pi,pi/2)) )
+
+        # Outer edge
+        if side_thickness > 0 :
+            outer_edge = Cylinder(radius=self.outer_diameter/2, length=side_thickness)
+            self.surflist.append( (outer_edge, (0,0,s1_defn.max_thickness+.5*side_thickness), (0,0,pi/2) ) )
+        elif side_thickness < 0 :
+            raise InvalidGeometryException("Lens is not thick enough to support surfaces.")
+
+        # Brim
+        self._add_brim(s1_defn, s1_defn.max_thickness)
+        if s2_defn is not None: self._add_brim(s2_defn, thickness-s2_defn.max_thickness)
+
+        # Apply offset
+        self._translate_origin(origin)
+
+    def _add_brim(self, defn, z_position):
+        """Adds an outer brim surface defined by surface definition defn.
+        Only applies is the specified outer diameter of this lens is larger
+        than the maximum diameter of the defined surface.
+        Brim will be located at postion z_position.
+        """
+        if self.outer_diameter > defn.diameter:
+            brim = Aperture(shape=Circular(radius=0.5*self.outer_diameter),
+                            ap_shape=Circular(radius=0.5*defn.diameter))
+            self.surflist.append( (brim, (0,0,z_position), (0,0,pi/2)) )
+        elif self.outer_diameter < defn.diameter:
+            raise InvalidGeometryException("Lens outer diameter can not be smaller than the diameter of an aspheric surface.")
+
+    def _translate_origin(self, origin):
+        """Move all elements so that the origin coincides with the origin
+        descriptor string, as documented in constructor.
+        """
+        # offset along the optical axis
+        selector = {'s1_min' : -1*self.s1_defn.max_thickness,
+                    's1_max' : 0,
+                    'center' : -0.5*self.thickness}
+        if self.s2_defn is not None:
+            selector['s2_min'] = -1*self.thickness + self.s2_defn.max_thickness,
+            selector['s2_max'] = -1*self.thickness,
+
+        try:
+            delta = selector[origin]
+        except KeyError:
+            raise ValueError('Invalid origin offset string.')
+
+        for k, v in self.surflist.items():
+            surface, translation, rotation = v
+            tx, ty, tz = translation
+            self.surflist[k] = (surface, (tx, ty, tz+delta), rotation)
+
+#TODO: move to a dedicated module
+class InvalidGeometryException(Exception):
+    pass

--- a/pyoptools/raytrace/comp_lib.py
+++ b/pyoptools/raytrace/comp_lib.py
@@ -7,7 +7,8 @@ This module hides from the end user un needed stuff.
 """
 
 # sorted is used so the clases are ordered alphabetically in the sphinx docs
-__all__ = sorted(["SphericalLens", "CylindricalLens", "CCD", "RightAnglePrism",
+__all__ = sorted(["SphericalLens", "AsphericLens, ""CylindricalLens",
+                  "CCD", "RightAnglePrism",
                   "PentaPrism", "DovePrism", "Block", "BeamSplitingCube",
                   "BeamSplittingCube",
                   "Doublet", "AirSpacedDoublet", "MultiLens", "Stop", "IdealLens",
@@ -15,6 +16,7 @@ __all__ = sorted(["SphericalLens", "CylindricalLens", "CCD", "RightAnglePrism",
                   "PowellLens"])
 
 from ._comp_lib.spherical_lens import SphericalLens
+from ._comp_lib.aspheric_lens import AsphericLens
 from ._comp_lib.cylindrical_lens import CylindricalLens
 from ._comp_lib.ccd import CCD
 from ._comp_lib.prism import RightAnglePrism, PentaPrism, DovePrism

--- a/pyoptools/raytrace/comp_lib.py
+++ b/pyoptools/raytrace/comp_lib.py
@@ -7,7 +7,7 @@ This module hides from the end user un needed stuff.
 """
 
 # sorted is used so the clases are ordered alphabetically in the sphinx docs
-__all__ = sorted(["SphericalLens", "AsphericLens, ""CylindricalLens",
+__all__ = sorted(["SphericalLens", "AsphericLens", "CylindricalLens",
                   "CCD", "RightAnglePrism",
                   "PentaPrism", "DovePrism", "Block", "BeamSplitingCube",
                   "BeamSplittingCube",

--- a/pyoptools/raytrace/ray/ray.pxd
+++ b/pyoptools/raytrace/ray/ray.pxd
@@ -4,22 +4,22 @@ from cpython cimport bool
 
 
 cdef class Ray:
-    cdef np.ndarray cpos 
-    cdef public object  n, parent, label
+    cdef np.ndarray cpos
+    cdef public object  n, parent, label, draw_color
     cdef public int order # In surfaces that produce multiple rays, each ray
                           # should be assigned a different order. This is done
                           # in the ray.add_child method
-                          
+
     cdef public list orig_surf # path of the originating surface
     cdef public double intensity, wavelength, pop
-    cdef list __childs, 
+    cdef list __childs,
     cdef np.ndarray _dir
-    
+
     cpdef Ray ch_coord_sys(self, np.ndarray no,np. ndarray ae)
     cpdef Ray ch_coord_sys_inv_f(self,np.ndarray no ,np.ndarray ae,bool childs)
-    
+
     #cpdef Ray ch_coord_sys(self, no, ae)
-    
+
 
     #~ def ch_coord_sys_inv(self,no,ae,childs=False):
     #~ def ch_coord_sys(self,no,ae):
@@ -30,4 +30,4 @@ cdef class Ray:
     #~ def optical_path_parent(self):
     #~ def optical_path(self):
 cdef Ray Rayf(np.ndarray pos,np.ndarray dir,double intensity,double wavelength,
-                n,label,parent,double pop,orig_surf,int order)
+                n,label,draw_color,parent,double pop,orig_surf,int order)

--- a/pyoptools/raytrace/ray/ray.pyx
+++ b/pyoptools/raytrace/ray/ray.pyx
@@ -1,6 +1,6 @@
 # cython: profile=True
 
-'''Ray class definition module 
+'''Ray class definition module
 '''
 
 cdef extern from "math.h":
@@ -35,31 +35,32 @@ np.import_array()
 
 #class Ray(HasPrivateTraits):
 
-# Trick to create instances of ray fast from a cython code. From python 
-# use the standard 
-# Note: when changing the code, always check that the __init__, and the 
+# Trick to create instances of ray fast from a cython code. From python
+# use the standard
+# Note: when changing the code, always check that the __init__, and the
 # Rayf initialization do the same.
 
 
 cdef Ray Rayf(np.ndarray pos,np.ndarray dir,double intensity,double wavelength,
-                n,label,parent,double pop,orig_surf,int order):
+                n,label,draw_color,parent,double pop,orig_surf,int order):
     """Function to create and initialize Ray instances Fast from cython
-    when changing the code, always check that the __init__, and the 
+    when changing the code, always check that the __init__, and the
     Rayf initialization do the same.
     """
-    # Code taken from: 
+    # Code taken from:
     #http://wiki.cython.org/FAQ#CanCythoncreateobjectsorapplyoperatorstolocallycreatedobjectsaspureCcode.3F
     cdef Ray instance = Ray.__new__(Ray)
-    
+
     instance.cpos=pos
-    
+
     #Be careful no normalization is made here
-    instance._dir=dir 
-    
+    instance._dir=dir
+
     instance.intensity=intensity
     instance.wavelength=wavelength
     instance.n=n
     instance.label=label
+    instance.draw_color=draw_color
     instance.parent=parent
     instance.pop=pop
     instance.orig_surf=orig_surf
@@ -70,117 +71,118 @@ cdef Ray Rayf(np.ndarray pos,np.ndarray dir,double intensity,double wavelength,
 
 cdef class Ray:
     """Class to define a ray
-    
+
     **ARGUMENTS**
-    
+
     =========== =======================================================
     pos         Tuple (x,y,z) containing the origin of the Ray
     dir         Tuple (x,y,z)  containing the direction vector of the Ray
-    intensity   Floating point number representing the Intensity of the 
+    intensity   Floating point number representing the Intensity of the
                 Ray.
-                Warning: Check how can a physically correct definition 
+                Warning: Check how can a physically correct definition
                 can be made
     wavelength  Wavelength (in vacuum) of the ray in micrometers
                 (.58929 by default)
     n           Refraction index of the point originating the ray.
-                If the value is None, the ray was emitted from the media 
-                and its Refraction index is taken (not from inside a 
+                If the value is None, the ray was emitted from the media
+                and its Refraction index is taken (not from inside a
                 component)
     label       String used to follow the rays through the system.
-    parent      Ray where this ray comes from (used to follow ray 
-                trajectory). 
-    childs      List of rays originated by the interaction of this ray 
+    parent      Ray where this ray comes from (used to follow ray
+                trajectory).
+    childs      List of rays originated by the interaction of this ray
                 with an optical surface.
     =========== =======================================================
     """
-    #~ # (x,y,z) tuple containing the ray origin 
+    #~ # (x,y,z) tuple containing the ray origin
     #~ pos=Array('d',shape=(3,),value=(0.,0.,0.))
-    #~ 
-    #~ # (x,y,z) tuple containing the unit vector representing the direction of 
+    #~
+    #~ # (x,y,z) tuple containing the unit vector representing the direction of
     #~ # propagation of the ray (this vector gets normalized automatically)
     #~ dir=UnitVector()
-    #~ 
+    #~
     #~ # Intensity of the ray.
     #~ intensity=Float(1)
-    #~ 
-    #~ # Wavelength of the ray in micrometers (.58929 by default) 
+    #~
+    #~ # Wavelength of the ray in micrometers (.58929 by default)
     #~ wavelength=Float(.58929)
-    #~ 
-    #~ # Refraction index of the point originating the ray. If the value is None, 
+    #~
+    #~ # Refraction index of the point originating the ray. If the value is None,
     #~ # the ray was emitted from the media (not from inside a component)
     #~ n=Trait(None,None,Float)
     #~
     #~ # Label to follow the rays through the system. This attribute propagates with
     #~ # the ray trace.
     #~ label=String("")
-    #~ 
-    #~ # Ray where this ray comes from. It is the ray before the interaction with the 
+    #~
+    #~ # Ray where this ray comes from. It is the ray before the interaction with the
     #~ # previous optical surface in the propagation
     #~ parent= This
-    #~ 
-    #~ # If this ray has no parent, use this value as the parent optical path. If 
-    #~ # the ray has a parent, this value must be ignored and instead the real 
+    #~
+    #~ # If this ray has no parent, use this value as the parent optical path. If
+    #~ # the ray has a parent, this value must be ignored and instead the real
     #~ # must be used.
     #~ pop= Float(0)
-    #~ 
+    #~
     #~ # Surface where the ray originates. All the rays not originated by interaction
-    #~ # with a Surface have this attribute set to None    
+    #~ # with a Surface have this attribute set to None
     #~ orig_surf=Any()
-    #~ 
-    
+    #~
+
     #in order for the autodocumentation to work, the method definition mut be in a single line
-    
-    def __init__(self,pos=(0,0,0),dir=(0,0,1),double intensity=1.,double wavelength=.58929, n=None,label="",parent=None,double pop=0.,orig_surf=None, order=0):
-                    
+
+    def __init__(self,pos=(0,0,0),dir=(0,0,1),double intensity=1.,double wavelength=.58929, n=None,label="",draw_color=None,parent=None,double pop=0.,orig_surf=None, order=0):
+
             self.pos=pos
             self.dir=dir
             self.intensity=intensity
             self.wavelength=wavelength
             self.n=n
             self.label=label
+            self.draw_color=draw_color
             self.parent=parent
             self.pop=pop
             self.orig_surf=orig_surf
             self.__childs=[]
             self.order=order
-        
+
         #HasPrivateTraits.__init__(self,**traits)
     def __reduce__(self):
-        args=(self.pos, self.dir,self.intensity,self.wavelength,self.n ,self.label,self.parent,self.pop,self.orig_surf,self.order)
+        args=(self.pos, self.dir,self.intensity,self.wavelength,self.n ,self.label,self.draw_color,self.parent,self.pop,self.orig_surf,self.order)
         return(type(self),args,self.__getstate__())
-    
+
     def __getstate__(self):
         return self.__childs
 
-    def __setstate__(self, state):                
+    def __setstate__(self, state):
         self.__childs=state
-            
+
     property childs:
         def __get__(self):
             # The list is converted to a tuple, so the internal list does not
-            # get exposed, and it can not be modified by accident using an 
+            # get exposed, and it can not be modified by accident using an
             # append
-       
+
             return tuple(self.__childs)
-            
-            # All internal lists that uses Properties are converted to 
+
+            # All internal lists that uses Properties are converted to
             # tuples to protect internal data.
 
     #~ __childs= Trait([],TraitList(Trait(This)))
-    #~ 
-    
+    #~
+
     #Correct way to define properties in cython
     property dir:
         def __get__(self):
             return self._dir
-        
+
         @cython.boundscheck(False)
-        @cython.wraparound(False)    
+        @cython.wraparound(False)
         def __set__(self,dir):
             """
-            This should create a normalized direction. Some times due to 
-            rounding errors |dir|>1. Caution must be taken so this do not create 
-            a problem 
+            This should create a normalized direction. Some times due to
+            rounding errors |dir|>1. Caution must be taken so this do not create
+            a problem
             """
             cdef np.ndarray[np.float64_t, ndim=1] adir=array(dir,dtype=float64)
             cdef double n
@@ -191,11 +193,11 @@ cdef class Ray:
             self._dir=adir
             #if (adir[0]*adir[0]+adir[1]*adir[1]+adir[2]*adir[2])>1:
             #    print "warning: The direction of a ray was not normalized correctly"
-            
-    #Use property pos to access the field cpos from a python program. 
+
+    #Use property pos to access the field cpos from a python program.
     #It can receive lists, tuples or arrays
     #the cython only visible cpos, can only receive arrays
-    property pos: 
+    property pos:
         def __get__(self):
             return self.cpos
         def __set__(self,pos):
@@ -203,22 +205,22 @@ cdef class Ray:
 
     def ch_coord_sys_inv(self,no,ae,childs=False):
         '''Transform the coordinate system of the Ray
-    
+
         Parameters
-        
+
         *no*
             Tuple (X,Y,Z) containing the coordinates of the origin of the
             old coordinate system in the new coordinate system
-        
+
         *ae*
             Tuple (RX,RY,RZ) containing the rotation angles to be applied to
             the  old coordinate system. The rotations are applied RZ first,
             then RY and last RX
-        
+
         *childs*
             Transform also the coordinate system of the childs. By default (False)
             don't do it.
-            
+
         The rotation is made first, and then the translation is made.
         Note, this has to be checked
         '''
@@ -227,13 +229,13 @@ cdef class Ray:
         npos=dot(tm,self.pos)+no
         ndir=dot(tm,self.dir)
         #parent=Ray(pos=npos,dir=ndir,intensity=self.intensity,
-        #        wavelength=self.wavelength,n=self.n, label=self.label, 
+        #        wavelength=self.wavelength,n=self.n, label=self.label,
         #        orig_surf=self.orig_surf)
-        
-        cdef Ray parent=Rayf(npos,ndir,self.intensity, self.wavelength, self.n, self.label, None ,0,self.orig_surf,self.order)
-               
+
+        cdef Ray parent=Rayf(npos,ndir,self.intensity, self.wavelength, self.n, self.label, self.draw_color, None ,0,self.orig_surf,self.order)
+
         # Calculate the transform of the childs and link them
-        
+
         if childs==True:
             for i in self.childs:
                 it=i.ch_coord_sys_inv(no,ae,childs)
@@ -242,24 +244,24 @@ cdef class Ray:
 
     cpdef Ray ch_coord_sys_inv_f(self,np.ndarray no ,np.ndarray ae,bool childs):
         '''Transform the coordinate system of the Ray
-    
-        Fast version 
-        
+
+        Fast version
+
         Parameters
-        
+
         *no*
             Tuple (X,Y,Z) containing the coordinates of the origin of the
             old coordinate system in the new coordinate system
-        
+
         *ae*
             Tuple (RX,RY,RZ) containing the rotation angles to be applied to
             the  old coordinate system. The rotations are applied RZ first,
             then RY and last RX
-        
+
         *childs*
             Transform also the coordinate system of the childs. By default (False)
             don't do it.
-            
+
         The rotation is made first, and then the translation is made.
         Note, this has to be checked
         '''
@@ -267,96 +269,96 @@ cdef class Ray:
         cdef np.ndarray tm=rot_mat(ae.astype(float64))
         cdef np.ndarray npos #=dot(tm,self.pos)+no
         cdef np.ndarray t
-        
+
         t=dot(tm,self.pos)
         npos = empty_vec(3)
-        
+
         cdef np.float64_t* nposd= <np.float64_t*>(np.PyArray_DATA(npos))
         cdef np.float64_t* nod= <np.float64_t*>(np.PyArray_DATA(no))
         cdef np.float64_t* td= <np.float64_t*>(np.PyArray_DATA(t))
-        
+
         nposd[0]=td[0]+nod[0]
         nposd[1]=td[1]+nod[1]
         nposd[2]=td[2]+nod[2]
-        
+
         ndir=dot(tm,self.dir)
 
-        cdef Ray parent=Rayf(npos,ndir,self.intensity, self.wavelength, self.n, self.label, None ,0,self.orig_surf,self.order)
-               
+        cdef Ray parent=Rayf(npos,ndir,self.intensity, self.wavelength, self.n, self.label, self.draw_color, None ,0,self.orig_surf,self.order)
+
         # Calculate the transform of the childs and link them
-        
+
         if childs:
             for i in self.childs:
                 it=i.ch_coord_sys_inv_f(no,ae,childs,True)
                 parent.add_child(it)
         return parent
-        
+
     @cython.boundscheck(False)
-    @cython.wraparound(False)    
+    @cython.wraparound(False)
     cpdef Ray ch_coord_sys(self, np.ndarray no, np.ndarray ae):
     #cpdef Ray ch_coord_sys(self, no, ae):
         '''Transform the coordinate system of the Ray
-    
+
         Parameters
-        no     
-        Tuple (X,Y,Z) containing the coordinates of the origin of the  new coordinate 
+        no
+        Tuple (X,Y,Z) containing the coordinates of the origin of the  new coordinate
         system in the old coordinate system
-        ae      
-        Tuple (RX,RY,RZ) containing the rotation angles to be applied to the  old 
+        ae
+        Tuple (RX,RY,RZ) containing the rotation angles to be applied to the  old
         coordinate system. The rotations are applied RZ first, then RY and last RX
-        
+
         Note this has to be checked
         '''
         #cdef np.ndarray tm=rot_mat_i(array(ae,dtype=float64))
         cdef np.ndarray tm=rot_mat_i(ae)
         cdef np.ndarray npos#=empty_vec( 3 )
         cdef np.ndarray ndir#=empty_vec( 3 )
-        
-        #mvdotf(<np.float64_t*>np.PyArray_DATA(npos), 
+
+        #mvdotf(<np.float64_t*>np.PyArray_DATA(npos),
         #        <np.float64_t*>np.PyArray_DATA(tm),<np.float64_t*>np.PyArray_DATA(array(self.pos-no,dtype=float64)))
 
-        #mvdotf(<np.float64_t*>np.PyArray_DATA(ndir), 
+        #mvdotf(<np.float64_t*>np.PyArray_DATA(ndir),
         #        <np.float64_t*>np.PyArray_DATA(tm),<np.float64_t*>np.PyArray_DATA(array(self.dir,dtype=float64)))
-        
+
         cdef np.ndarray t = empty_vec(3)
-        
+
         #t=self.cpos-no
-        
+
         #(<np.float64_t*>np.PyArray_DATA(t))[0]=(<np.float64_t*>np.PyArray_DATA(self.cpos))[0]-(<np.float64_t*>np.PyArray_DATA(no))[0]
         #(<np.float64_t*>np.PyArray_DATA(t))[1]=(<np.float64_t*>np.PyArray_DATA(self.cpos))[1]-(<np.float64_t*>np.PyArray_DATA(no))[1]
         #(<np.float64_t*>np.PyArray_DATA(t))[2]=(<np.float64_t*>np.PyArray_DATA(self.cpos))[2]-(<np.float64_t*>np.PyArray_DATA(no))[2]
-        
+
         cdef np.float64_t* td= <np.float64_t*>(np.PyArray_DATA(t))
         cdef np.float64_t* cd= <np.float64_t*>(np.PyArray_DATA(self.cpos))
         cdef np.float64_t* nd= <np.float64_t*>(np.PyArray_DATA(no))
-        
+
         td[0]=cd[0]-nd[0]
         td[1]=cd[1]-nd[1]
         td[2]=cd[2]-nd[2]
-        
+
         npos=dot(tm,t)        # if blas can be called directly, this can be improved
         ndir=dot(tm,self._dir) # Using tokio this tokio works a little faster, but have to see
                               #How to install it right, or better to do something similar using inline snd blas
-        
+
         #tokyo.dgemv3( tm, t, npos )
         #tokyo.dgemv3( tm, self.dir, ndir )
-        #This resulted to be slower 
+        #This resulted to be slower
         #npos=mvdot1(tm,t)
         #ndir=mvdot1(tm,self.dir)
-        
-        return Rayf(npos,ndir,self.intensity, self.wavelength, self.n, self.label, None ,0,self.orig_surf,self.order)
+
+        return Rayf(npos,ndir,self.intensity, self.wavelength, self.n, self.label, self.draw_color, None ,0,self.orig_surf,self.order)
 
     def get_final_rays(self, inc_zeros=True):
         '''Find the final rays of the raytrace
-        
+
         *inc_zeros*
-            If inc_zeros == True, all the child rays are included.  
+            If inc_zeros == True, all the child rays are included.
             If set to false, the rays with intensity==0 are not
             included
         '''
-        
+
         retval=[]
-        
+
         if len(self.childs)==0:
             if(inc_zeros):
                 retval=[self]
@@ -369,9 +371,9 @@ cdef class Ray:
             for i in self.childs:
                 retval=retval+i.get_final_rays(inc_zeros)
         return retval
-        
+
     def copy(self):
-        '''Return a copy ray leaving the parent=None, and childs=[], and 
+        '''Return a copy ray leaving the parent=None, and childs=[], and
         order=0
         '''
         return Ray(pos=self.pos,dir=self.dir,intensity=self.intensity,
@@ -382,10 +384,10 @@ cdef class Ray:
         order=0, and inverting the ray direction.
         '''
         return Ray(pos=self.pos,dir=-self.dir,intensity=self.intensity,
-                    wavelength=self.wavelength,n=self.n,label=self.label, 
+                    wavelength=self.wavelength,n=self.n,label=self.label,
                     orig_surf=self.orig_surf)
 
-    def __repr__(self):        
+    def __repr__(self):
         # TODO: why 'direc' and not 'dir' ? This is confusing
         return "Ray(pos="+repr(self.pos)+",direc="+repr(self.dir)+\
             ",intensity="+repr(self.intensity)+",wavelength="+\
@@ -394,11 +396,11 @@ cdef class Ray:
 
     def add_child(self, cr):
         '''Add childs to the current ray, and create the appropiate links
-        
+
         *cr*
             Ray to include in the child list
         '''
-        
+
         # A child with intensity==0 is used to indicate a parent end point, for
         # example the intersection point with a stop, so it must be in the
         # list as a child.
@@ -406,27 +408,27 @@ cdef class Ray:
         cr.parent=self
         cr.order=len(self.__childs)
         self.__childs.append(cr)
-        
+
     def optical_path_parent(self):
         ''' Return the optical path from the origin of the origin ray to the
        end of this ray parent (this ray origin)
         '''
-        
+
         if self.parent is not None:
-            if self.pop!=0: 
+            if self.pop!=0:
                 print "The pop attribute of the ray has a value of ", self.pop, \
                 " instead the real parent optical path is being used"
             path= sqrt(dot(self.pos-self.parent.pos,self.pos-self.parent.pos))*\
                     self.parent.n
             return path+self.parent.optical_path_parent()
-        
+
         return self.pop
 
     def optical_path(self):
         ''' Return the optical path of the beam propagation from the origin of
         the origin ray, to the end of this ray (intersection with a surface)
         '''
-        
+
         if self.intensity==0:
             return 0.
         elif len(self.childs)==0:
@@ -441,6 +443,7 @@ cdef class Ray:
         self.wavelength == other.wavelength and\
         self.n == other.n and\
         self.label == other.label and\
+        self.draw_color == other.draw_color and\
         self.order == other.order and\
         self.orig_surf == other.orig_surf
         # TODO do we have to compare self.pop and other.pop ?
@@ -453,16 +456,16 @@ cdef class Ray:
         Test if two rays are equal up to desired precision.
 
         **ARGUMENTS**
-        
+
             ======= ===============================================
             other   Ray other ray to be compared against.
             decimal int, optional, Desired precision, default is 7.
             ======= ===============================================
-  
+
 
         **RETURN VALUE**
-            bool   True if two rays are equal to the desired precision. i.e. 
-                   if abs(self - other) < 1.5 * 10**(-decimal) for attributes 
+            bool   True if two rays are equal to the desired precision. i.e.
+                   if abs(self - other) < 1.5 * 10**(-decimal) for attributes
                    pos, dir, wavelength and n.
         """
         atol = 1.5 * 10 ** (-decimal)
@@ -474,6 +477,7 @@ cdef class Ray:
                np.allclose(ray1.wavelength, ray2.wavelength, rtol=rtol, atol=atol) and \
                ray1.n == ray2.n and \
                ray1.label == ray2.label and \
+               ray1.draw_color == ray2.draw_color and \
                ray1.order == ray2.order and \
                ray1.orig_surf == ray2.orig_surf
         # TODO do we have to compare self.pop and other.pop ?

--- a/pyoptools/raytrace/ray/ray.pyx
+++ b/pyoptools/raytrace/ray/ray.pyx
@@ -88,6 +88,9 @@ cdef class Ray:
                 and its Refraction index is taken (not from inside a
                 component)
     label       String used to follow the rays through the system.
+    draw_color  Color used to render this ray. If None, the wavelength
+                will be used to determine the color. Otherwise, can be
+                any valid matplotlib color identifier.
     parent      Ray where this ray comes from (used to follow ray
                 trajectory).
     childs      List of rays originated by the interaction of this ray

--- a/pyoptools/raytrace/ray/ray_source.py
+++ b/pyoptools/raytrace/ray/ray_source.py
@@ -11,27 +11,30 @@ from numpy.random import normal
 
 from .ray import Ray
 
+def parallel_beam_c(origin=(0.,0.,0.),direction=(0.,0.,0.),size=(1.,1.),num_rays=(10,10),wavelength=0.58929, label="", draw_color=None):
+    """Cartesian grid parallel beam
 
+    This function creates a parallel beam, where the rays are organized in a
+    cartesian grid.
 
-def parallel_beam_c(origin=(0.,0.,0.),direction=(0.,0.,0.),size=(1.,1.),num_rays=(10,10),wavelength=0.58929, label=""):
-    """Cartesian grid parallel beam 
-    
-    This function creates a parallel beam, where the rays are organized in a 
-    cartesian grid. 
-    
     Parameters:
-    
-    
+
+
     *origin*
-        Tuple with the coordinates of the central ray origin 
+        Tuple with the coordinates of the central ray origin
     *direction*
         Tuple with the rotation of the beam around the XYZ axes.
     *size*
         Tuple with the beam's width and the height.
     *num_rays*
-        Tuple (nx,ny) containing the number of rays used to create the beam. 
+        Tuple (nx,ny) containing the number of rays used to create the beam.
     *label*
         String used to identify the ray source
+    *draw_color*
+        Color used to represent the rays in plots. Default (None) automatically
+        chooses a color based on the wavelength. Otherwise, can be any valid
+        matplotlib color descriptor. See :
+            https://matplotlib.org/3.3.1/api/colors_api.html
     """
 
     ret_val=[]
@@ -42,37 +45,44 @@ def parallel_beam_c(origin=(0.,0.,0.),direction=(0.,0.,0.),size=(1.,1.),num_rays
     # note modify this to use traits
     dx=float(dx)
     dy=float(dy)
-    
+
     for ix in range(nx):
         for iy in range(ny):
             x=-dx/2.+dx*ix/(nx-1)
             y=-dy/2.+dy*iy/(ny-1)
             ret_val.append(Ray(pos=(x,y,0),
                                dir=(0,0,1),
-                               wavelength=wavelength, label=label).ch_coord_sys_inv(origin,direction))
+                               wavelength=wavelength,
+                               label=label,
+                               draw_color=draw_color).ch_coord_sys_inv(origin,direction))
     return ret_val
 
-def parallel_beam_p(origin=(0.,0.,0.),direction=(0.,0.,0),radius=0.5, num_rays=(5,10),wavelength=0.58929, label=""):
+def parallel_beam_p(origin=(0.,0.,0.),direction=(0.,0.,0),radius=0.5, num_rays=(5,10),wavelength=0.58929, label="", draw_color=None):
     """Polar grid parallel beam
-    
-    This function creates a parallel beam, where the rays are organized in a 
-    polar grid. 
-    
+
+    This function creates a parallel beam, where the rays are organized in a
+    polar grid.
+
     Parameters:
-   
-    
+
+
     *origin*
-        Tuple with the coordinates of the central ray origin 
+        Tuple with the coordinates of the central ray origin
     *direction*
         Tuple with the rotation of the beam around the XYZ axes.
     *r*
-        Beam radious 
+        Beam radious
     *num_rays*
-        Tuple (nr,na) containing the number of rays used to create the beam. 
+        Tuple (nr,na) containing the number of rays used to create the beam.
     *label*
         String used to identify the ray source
+    *draw_color*
+        Color used to represent the rays in plots. Default (None) automatically
+        chooses a color based on the wavelength. Otherwise, can be any valid
+        matplotlib color descriptor. See :
+            https://matplotlib.org/3.3.1/api/colors_api.html
     """
-    
+
     ret_val=[Ray(pos=(0,0,0),dir=(0,0,1),wavelength=wavelength, label=label).ch_coord_sys_inv(origin,direction)]
     nr,nt=num_rays
     for r_ in range(1,nr):
@@ -82,63 +92,68 @@ def parallel_beam_p(origin=(0.,0.,0.),direction=(0.,0.,0),radius=0.5, num_rays=(
             y_=r*cos(2*pi*t/nt)
             ret_val.append(Ray(pos=(x_,y_,0),
                                dir=(0,0,1),
-                               wavelength=wavelength,label=label
-                               ).ch_coord_sys_inv(origin,direction))
+                               wavelength=wavelength,
+                               label=label,
+                               draw_color=draw_color).ch_coord_sys_inv(origin,direction))
     return ret_val
 
 def point_source_c(origin=(0.,0.,0.),direction=(0.,0.,0),span=(pi/8,pi/8)\
-                     ,num_rays=(10,10),wavelength=0.58929, label=""):
-    """Point source, with a cartesian beam distribution 
-    
-    This function creates a point source, where the rays are organized in a 
-    cartesian grid. 
-    
+                     ,num_rays=(10,10),wavelength=0.58929, label="", draw_color=None):
+    """Point source, with a cartesian beam distribution
+
+    This function creates a point source, where the rays are organized in a
+    cartesian grid.
+
     Parameters:
-    
-    
+
+
     *origin*
-        Tuple with the coordinates of the central ray origin 
+        Tuple with the coordinates of the central ray origin
     *direction*
         Tuple with the rotation of the beam around the XYZ axes.
     *span*
         Tuple angular size of the ray pencil.
     *num_rays*
-        Tuple (nx,ny) containing the number of rays used to create the beam. 
+        Tuple (nx,ny) containing the number of rays used to create the beam.
     *label*
         String used to identify the ray source
+    *draw_color*
+        Color used to represent the rays in plots. Default (None) automatically
+        chooses a color based on the wavelength. Otherwise, can be any valid
+        matplotlib color descriptor. See :
+            https://matplotlib.org/3.3.1/api/colors_api.html
     """
     ret_val=[]
 
     nx,ny=num_rays
     dx,dy=span
-        
+
     for ix in range(nx):
         for iy in range(ny):
             if nx!=1: tx=-dx/2.+dx*ix/(nx-1)
             else: tx=0.
-            
+
             if ny!=1: ty=-dy/2.+dy*iy/(ny-1)
             else: ty=0.
             temp_ray=Ray(pos=(0,0,0),
                          dir=(0,0,1),
-                         wavelength=wavelength, label=label
-                         ).ch_coord_sys_inv((0,0,0),(tx,ty,0))
+                         wavelength=wavelength,
+                         label=label,
+                         draw_color=draw_color).ch_coord_sys_inv((0,0,0),(tx,ty,0))
             ret_val.append(temp_ray.ch_coord_sys_inv(origin,direction))
     return ret_val
 
-
-
-def point_source_p(origin=(0.,0.,0.),direction=(0.,0.,0),span=pi/8,num_rays=(10,10),wavelength=0.58929, label=""):
+def point_source_p(origin=(0.,0.,0.),direction=(0.,0.,0),span=pi/8,num_rays=(10,10),wavelength=0.58929, label="", draw_color=None):
     """Point source, with a polar beam distribution
-    
-    This function creates a point source, where the rays are organized in a 
-    polar grid. 
-    
+
+    This function creates a point source, where the rays are organized in a
+    polar grid.
+
     Parameters:
-    
-    
+
+
     *origin*
-        Tuple with the coordinates of the central ray origin 
+        Tuple with the coordinates of the central ray origin
     *direction*
         Tuple with the rotation of the beam around the XYZ axes.
     *span*
@@ -149,13 +164,20 @@ def point_source_p(origin=(0.,0.,0.),direction=(0.,0.,0),span=pi/8,num_rays=(10,
         # TODO What is na?
     *label*
         String used to identify the ray source
+    *draw_color*
+        Color used to represent the rays in plots. Default (None) automatically
+        chooses a color based on the wavelength. Otherwise, can be any valid
+        matplotlib color descriptor. See :
+            https://matplotlib.org/3.3.1/api/colors_api.html
     """
 
     ret_val=[Ray(pos=(0,0,0),dir=(0,0,1),wavelength=wavelength, label=label).ch_coord_sys_inv(origin,direction)]
+
     nr,nt=num_rays
+
     for r_ in range(1,nr):
         r=span*float(r_)/nr
-        temp_ray=Ray(pos=(0,0,0),dir=(0,0,1),wavelength=wavelength, label=label).ch_coord_sys_inv((0,0,0),(r,0,0))
+        temp_ray=Ray(pos=(0,0,0),dir=(0,0,1),wavelength=wavelength, label=label, draw_color=draw_color).ch_coord_sys_inv((0,0,0),(r,0,0))
         for t in range(nt):
             tz=2*pi*t/nt
             temp_ray1=temp_ray.ch_coord_sys_inv((0,0,0),(0,0,tz))
@@ -163,17 +185,17 @@ def point_source_p(origin=(0.,0.,0.),direction=(0.,0.,0),span=pi/8,num_rays=(10,
     return ret_val
 
 
-def point_source_r(origin=(0.,0.,0.),direction=(0.,0.,0),span=pi/8,num_rays=100,wavelength=0.58929, label=""):
+def point_source_r(origin=(0.,0.,0.),direction=(0.,0.,0),span=pi/8,num_rays=100,wavelength=0.58929, label="", draw_color=None):
     """Point source, with a ranrom beam distribution
-    
-    This function creates a point source, where the rays are organized in a 
-    random grid. 
-    
+
+    This function creates a point source, where the rays are organized in a
+    random grid.
+
     Parameters:
-   
-    
+
+
     *origin*
-        Tuple with the coordinates of the central ray origin 
+        Tuple with the coordinates of the central ray origin
     *direction*
         Tuple with the rotation of the beam around the XYZ axes.
     *span*
@@ -182,13 +204,18 @@ def point_source_r(origin=(0.,0.,0.),direction=(0.,0.,0),span=pi/8,num_rays=100,
         Number of rays used to create the beam
     *label*
         String used to identify the ray source
+    *draw_color*
+        Color used to represent the rays in plots. Default (None) automatically
+        chooses a color based on the wavelength. Otherwise, can be any valid
+        matplotlib color descriptor. See :
+            https://matplotlib.org/3.3.1/api/colors_api.html
     """
 
     ret_val=[]
-    
+
     for n_ in range(num_rays):
         rx=normal(0,span)
         ry=normal(0,span)
-        temp_ray=Ray(pos=(0,0,0),dir=(0,0,1),wavelength=wavelength, label=label).ch_coord_sys_inv((0,0,0),(rx,ry,0))
+        temp_ray=Ray(pos=(0,0,0),dir=(0,0,1),wavelength=wavelength, label=label, draw_color=draw_color).ch_coord_sys_inv((0,0,0),(rx,ry,0))
         ret_val.append(temp_ray.ch_coord_sys_inv(origin,direction))
     return ret_val

--- a/pyoptools/raytrace/surface/surface.pyx
+++ b/pyoptools/raytrace/surface/surface.pyx
@@ -23,7 +23,7 @@ cdef extern from "math.h":
     double sqrt(double) nogil
     double acos(double) nogil
     double cos(double) nogil
-    bint isnan(double x) nogil 
+    bint isnan(double x) nogil
 
 cdef double pi= 3.1415926535897931
 
@@ -70,29 +70,29 @@ cdef class Surface(Picklable):
     '''
     :class:`Surface` is an abstract superclass for all optical surface objects.
     This class defines an API that all subclasses must support.
-    
+
     All Surface subclasses share the attributes reflectivity, and shape,
     that are defined as follows:
-    
+
     ============  =========================================================
-    reflectivity  Float point number between 0 and 1. 0 indicates a 
+    reflectivity  Float point number between 0 and 1. 0 indicates a
                   completely transparent surface, 1 a completely reflective
                   surface. A value between are beam spliters.
     shape         Instance of the :class:`Shape`, that indicates the
                   surface's aperture shape.
     ============  =========================================================
-    
-    Each surface stores a hit_list, so the ray impact information can be 
+
+    Each surface stores a hit_list, so the ray impact information can be
     obtained. This list records the point of impact in the surface reference
     system, and a pointer to the hitting ray so intensity, wavelength, and other
     information about the ray can be retrieved. The reset method, clear this
     lists.
-    
+
     '''
-    
-    #A reflectivity=0 indicates a transparent surface and a reflectivity =1 
+
+    #A reflectivity=0 indicates a transparent surface and a reflectivity =1
     #'''
-    
+
     #    indicates a perfect mirror. A value in between, indicates a beam splitter. The shape
     #    attribute is used to define the perimeter of the surface, and it is an
     #    instance of the Shape class.
@@ -106,22 +106,22 @@ cdef class Surface(Picklable):
         self.id =[] # The id of each surface gets registered when the component
                     #is created, and when the system is created
         Picklable.__init__(self,"reflectivity", "shape", "_hit_list","id")
-        
-            
-        
+
+
+
     property hit_list:
         def __get__(self):
             # The list is converted to a tuple, so the internal list does not
-            # get exposed, and it can not be modified by accident using an 
+            # get exposed, and it can not be modified by accident using an
             # append
             return self._hit_list
-        
-        
-    
+
+
+
     cpdef topo(self, x, y):
         '''Method that returns the topography of the surface
-        
-        The matrix returned is :math:`z=f(x,y)`. This method mus be overloaded in all 
+
+        The matrix returned is :math:`z=f(x,y)`. This method mus be overloaded in all
         subclases of Surface.
         '''
         warn("Method topo, from class Surface, should be overloaded"+
@@ -129,54 +129,54 @@ cdef class Surface(Picklable):
 
     cpdef int_nor(self,Ray iray):
         '''Point of intersection between a ray and a surface and the normal.
-        
+
         Method that returns the point of intersection between a surface and
         a ray, and the vector normal to this point. I must return a tuple
-        of the form ``((ix,iyi,z),(nx,ny,nz))``, where ``ix,iy,iz`` are the 
-        coordinates of the intersection point, and nx,ny,nz are the components 
+        of the form ``((ix,iyi,z),(nx,ny,nz))``, where ``ix,iy,iz`` are the
+        coordinates of the intersection point, and nx,ny,nz are the components
         of the vector normal to the surface.
-        
+
         **Arguments:**
-        
+
              iray -- incident ray in the coordinate system of the surface.
-        
-        This method uses surface.intersection, surface.normal, and 
+
+        This method uses surface.intersection, surface.normal, and
         surface.shape.hit
         '''
 
         int_p= self.intersection(iray)
         N_= self.normal(int_p)
-        
+
         # Check if the ray crosses the aperture
-                    
+
         return int_p, N_
 
 
     cpdef np.ndarray  normal(self, int_p):
         '''Normal vector at the point ip.
-        
-        This method returns the normal vector at a specific intersection point, 
+
+        This method returns the normal vector at a specific intersection point,
         given by ip. The normal vector must be normalized.
-         
+
         This method must be overloaded in all Surface subclases. It contains
         the geometric specific code.
-        
+
         **Arguments:**
-        
+
         iray -- incident ray in the coordinate system of the surface.
 
-        
+
         **Returns:**
-        
+
         An array [dx,dy,dz] indicating the vector normal to the surface
         '''
-            
+
         warn("Method normal from class Surface, should be overloaded"+
              " in class "+self.__class__.__name__)
-        
+
     cpdef np.ndarray intersection(self,Ray iray):
         '''Point of intersection between a ray and a surface.
-        
+
         This method returns the point of intersection  between the surface
         and the ray. This intersection point is calculated in the coordinate
         system of the surface.
@@ -185,22 +185,22 @@ cdef class Surface(Picklable):
         element aperture, it must return (numpy.inf,numpy.inf,numpy.inf)
 
         **Arguments:**
-        
+
         iray -- incident ray
-            
+
         iray must be in the coordinate system of the surface
-        
+
         **Returns:**
-        
-        A vector [x,y,z] containing the coordinates of the point of 
+
+        A vector [x,y,z] containing the coordinates of the point of
         intersection between the ray and the surface. If there is no
         intersection returns [Inf, Inf, Inf].
-        
+
         .. note::
-            This method does not need to be overloaded. Overload 
+            This method does not need to be overloaded. Overload
             :meth:`surface._intersection` instead.
         '''
-        
+
         int_p= self._intersection(iray)
 
         if self.shape.fhit(int_p[0],int_p[1],int_p[2])==False:
@@ -214,143 +214,143 @@ cdef class Surface(Picklable):
         This method returns the point of intersection  between the surface
         and the ray. This intersection point is calculated in surface coordinate
         system.
-        
-        This method should not check for the aperture  
-     
+
+        This method should not check for the aperture
+
         **Arguments:**
-                
+
         ``iray`` -- incident ray
 
         iray must be in the coordinate system of the surface
 
-        This function must be overloaded in all :class:`Surface` subclases. 
-        It contains the geometric specific code. It must not  check for 
+        This function must be overloaded in all :class:`Surface` subclases.
+        It contains the geometric specific code. It must not  check for
         the aperture.
-        
-        This function must not be called directly. You should call 
+
+        This function must not be called directly. You should call
         :meth:`Surface.intersection` instead.
         '''
         warn("Method _intersection, from class Surface, should be overloaded"+
              " in class "+self.__class__.__name__)
-             
+
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    
+
     cpdef distance(self,Ray iray):
         '''Distance propagated by a ray until intersection with a surface.
-        
+
         This method returns the distance propagated by a ray since its origin
         and its point of intersection with a surface.
-        
+
         **Args:**
-        
-        ``iray`` 
-            Incident ray, iray must be in the coordinate system of the 
+
+        ``iray``
+            Incident ray, iray must be in the coordinate system of the
             surface
-        
+
         **Returns:**
-        
+
         A tuple ``(distance,point_of_intersection, surface)``, where:
-        
+
         ``distance``
-            The distance from the ray origin to the point of intersection 
+            The distance from the ray origin to the point of intersection
             with the surface
         ``point_of_intersection``
-            The point of intersection using the coordinate system of the 
-            surface 
+            The point of intersection using the coordinate system of the
+            surface
         ``surface``
-            a pointer to the surface 
-        
+            a pointer to the surface
+
         '''
-#~ 
-        
+#~
+
         cdef np.ndarray[np.double_t, ndim=1] PI=self.intersection(iray)
         cdef double Dist
-        # Dist is positive if the current surface is ahead of the ray. 
+        # Dist is positive if the current surface is ahead of the ray.
         # If the surface is behind the ray, Dist becomes negative
         # If there is no intersection, Dist becomes inf
         if isinf(PI[0]) or isinf(PI[1]) or isinf(PI[2]) :#sometrue(isinf(PI)):
         #if PI[0]==inf or PI[0]==inf or PI[0]==inf:
-            Dist=infty 
+            Dist=infty
         else:
             Dist= dot(PI-iray.pos,iray.dir)
-        
+
         if Dist>1e10:Dist=infty
 
         # Because of rounding errors, some times when the distance should be 0
-        # It gives a very small number. A distance is too small, or 0 means 
+        # It gives a very small number. A distance is too small, or 0 means
         # that the ray was already refracted by the surface, and the surface
         # is already behind the ray.
-        
-        if Dist<1.e-10 : Dist= infty 
+
+        if Dist<1.e-10 : Dist= infty
 
         return Dist,PI
-        
+
     cpdef distance_s(self,Ray iray):
         '''Distance propagated by a ray until intersection with a surface.
-        
+
         This method returns the distance propagated by a ray since its origin
-        and its point of intersection with a surface. This method returns 
+        and its point of intersection with a surface. This method returns
         positive and negative distances, and does not check for apertures.
-        
+
         Arguments:
-                
+
             iray -- incident ray
 
         iray must be in the coordinate system of the surface
-        
+
         Return value:
-        
+
             A tuple with the distance, the point of intersection using the
-            coordinate system of the surface, and a pointer to the surface 
+            coordinate system of the surface, and a pointer to the surface
             (distance,point of intersection, surface)
         '''
 
-        
+
         PI=self._intersection(iray)
-        
-        # Dist is positive if the current surface is ahead of the ray. 
+
+        # Dist is positive if the current surface is ahead of the ray.
         # If the surface is behind the ray, Dist becomes negative
         # If there is no intersection, Dist becomes inf
         if isinf(PI[0]) or isinf(PI[1]) or isinf(PI[2]):
             Dist=inf
         else:
             Dist= dot(PI-iray.pos,iray.dir)
-        
+
         if abs(Dist)>1e10:Dist=inf
 
         return Dist,PI# ,self
-        
+
     @cython.boundscheck(False)
     @cython.wraparound(False)
     cpdef propagate(self,Ray ri,double ni,double nr):
         '''Method to calculate the ray refracted on a surface.
 
-        This method calculates the ray refracted (or rays refracted and 
+        This method calculates the ray refracted (or rays refracted and
         reflected)on a surface.
-        
+
         Arguments:
-        
+
 
              ri -- incident ray
-             
+
              ni -- refraction index in the incident media n.
-             
+
              nr -- refraction index in the refracted media
 
         ri must be in the coordinate system of the surface
         '''
         cdef double I,IA,gamma,gamma1,R
         cdef np.ndarray S1,PI,P,S2,A,A1,S3
-        
-        cdef np.float64_t *S1p  
-        cdef np.float64_t *PIp  
-        cdef np.float64_t *Pp  
-        cdef np.float64_t *S2p 
-        cdef np.float64_t *Ap  
-        cdef np.float64_t *A1p 
-        cdef np.float64_t *S3p 
-        
+
+        cdef np.float64_t *S1p
+        cdef np.float64_t *PIp
+        cdef np.float64_t *Pp
+        cdef np.float64_t *S2p
+        cdef np.float64_t *Ap
+        cdef np.float64_t *A1p
+        cdef np.float64_t *S3p
+
         # Calculate the point of intersection of the ray with the surface, and
         # the normal vector to this point
         # The int_nor method should be overridden by each Surface subclasses
@@ -358,25 +358,25 @@ cdef class Surface(Picklable):
         #PI,P=self.int_nor(ri)
         PI= self.intersection(ri)
         P=  self.normal(PI)
-        
+
         PIp = <np.float64_t *>np.PyArray_DATA(PI)
         Pp = <np.float64_t *>np.PyArray_DATA(P)
-        
-        
+
+
         # The information is added in the  system.propagate_ray method.
         # Add the information to the hitlist
         # self._hit_list.append((PI, ri))
-        
+
         S1=ri._dir*ni #Use the numpy array instead the property. it is faster.
         S1p = <np.float64_t *>np.PyArray_DATA(S1)
-        
-        
+
+
 
         # Calculate the incident angle
         cdef double ddot=dot(S1,P)
         I=(acos(ddot/ni))
-        
-        
+
+
         #some times because rounding errors |ri.dir|>1. In this cases
         #I=nan
         if isnan(I): I=0.
@@ -390,15 +390,15 @@ cdef class Surface(Picklable):
             Pp[2]=-Pp[2]
             ddot=dot(S1,P)
             I=(acos(ddot/ni))
-        
-        
-        
-       
-        
-        
+
+
+
+
+
+
         gamma= nr*sqrt((ni/nr*cos(I))**2 -(ni/nr)**2+1.)- ni*cos(I)
-        
-       
+
+
         #A=gamma*P
         A=empty_vec(3)
         Ap = <np.float64_t *>np.PyArray_DATA(A)
@@ -414,13 +414,13 @@ cdef class Surface(Picklable):
         S2p[0]=S1p[0]+Ap[0]
         S2p[1]=S1p[1]+Ap[1]
         S2p[2]=S1p[2]+Ap[2]
-        
+
         #S2=nr*(norm_vect(S2))
         norm_vect(S2)
         S2p[0]=nr*S2p[0]
         S2p[1]=nr*S2p[1]
         S2p[2]=nr*S2p[2]
-       
+
         #R=acos(dot(S2/nr,P))
 
         # If the refraction index is negative, the surface should behave
@@ -428,12 +428,12 @@ cdef class Surface(Picklable):
 
         # If reflectivity==0 the optical surface is not a BeamSplitter
 
-        # If there is total internal reflection, the surface should not 
+        # If there is total internal reflection, the surface should not
         # behave as a BeamSplitter
 
         # If the optical system is a BeamSplitter this method should return
         # a list [Transmitted ray, Reflected ray]
-        
+
         #Note the fast ray creation function do not normalize the dir of the ray
         norm_vect(S2) #S2/sqrt(dot(S2,S2))
 
@@ -455,25 +455,25 @@ cdef class Surface(Picklable):
             return [Ray(pos=PI,dir=-S2,intensity=ri.intensity,
                         wavelength=ri.wavelength,n=absolute(ni),
                         label=ri.label, orig_surf=self.id)]
-            
+
 
         elif (reflect ==0) and not(sometrue(npisnan(S2))):
             # Normal refraction case
             #return [Ray(pos=PI,dir=S2,intensity=ri.intensity,
             #           wavelength=ri.wavelength,n=nr,
             #           label=ri.label, orig_surf=self.id)]
-            return [Rayf(PI,S2,ri.intensity, ri.wavelength, nr, ri.label, None ,0,self.id,0)]
+            return [Rayf(PI,S2,ri.intensity, ri.wavelength, nr, ri.label, ri.draw_color, None ,0,self.id,0)]
         elif sometrue(npisnan(S2)):
             # Total internal refraction case
             gamma1= -2.*ni*cos(I)
-        
+
             #A1=gamma1*P
             A1=empty_vec(3)
             A1p = <np.float64_t *>np.PyArray_DATA(A1)
             A1p[0]=gamma1*Pp[0]
             A1p[1]=gamma1*Pp[1]
             A1p[2]=gamma1*Pp[2]
-            
+
             #S3=S1+A1
             S3=empty_vec(3)
             S3p = <np.float64_t *>np.PyArray_DATA(S3)
@@ -481,16 +481,16 @@ cdef class Surface(Picklable):
             S3p[1]=S1p[1]+A1p[1]
             S3p[2]=S1p[2]+A1p[2]
 
-        
+
             norm_vect(S3) #S3=S3/sqrt(dot(S3,S3))
-        
-        
+
+
             #return [Ray(pos=PI,dir=S3,
             #            intensity=ri.intensity,
             #            wavelength=ri.wavelength,n=ni,
             #            label=ri.label, orig_surf=self.id)]
-            return [Rayf(PI,S3,ri.intensity, ri.wavelength, ni, ri.label, None ,0,self.id,0)]
-             
+            return [Rayf(PI,S3,ri.intensity, ri.wavelength, ni, ri.label, ri.draw_color, None ,0,self.id,0)]
+
         else:
             # BeamSplitter case
             gamma1= -2.*ni*cos(I)
@@ -500,7 +500,7 @@ cdef class Surface(Picklable):
             A1p[0]=gamma1*Pp[0]
             A1p[1]=gamma1*Pp[1]
             A1p[2]=gamma1*Pp[2]
-            
+
             #S3=S1+A1
             S3=empty_vec(3)
             S3p = <np.float64_t *>np.PyArray_DATA(S3)
@@ -513,76 +513,76 @@ cdef class Surface(Picklable):
                 return [#Ray(pos=PI,dir=S2,
                         #    intensity=ri.intensity*(1.-self.reflectivity),
                         #    wavelength=ri.wavelength,n=nr, label=ri.label, orig_surf=self.id),
-                        Rayf(PI,S2,ri.intensity*(1.-reflect), ri.wavelength, nr, ri.label, None ,0,self.id,0),
+                        Rayf(PI,S2,ri.intensity*(1.-reflect), ri.wavelength, nr, ri.label, ri.draw_color, None ,0,self.id,0),
                         #Ray(pos=PI,dir=S3,
                         #    intensity=ri.intensity*self.reflectivity,
                         #    wavelength=ri.wavelength,n=ni,label=ri.label, orig_surf=self.id)
-                        Rayf(PI,S3,ri.intensity*reflect, ri.wavelength, ni, ri.label, None ,0,self.id,0)
+                        Rayf(PI,S3,ri.intensity*reflect, ri.wavelength, ni, ri.label, ri.draw_color, None ,0,self.id,0)
                         ]
             else:
                 #return [Ray(pos=PI,dir=S3,
                 #            intensity=ri.intensity*self.reflectivity,
                 #            wavelength=ri.wavelength,n=ni,label=ri.label, orig_surf=self.id)]
-                return [Rayf(PI,S3,ri.intensity, ri.wavelength, ni, ri.label, None ,0,self.id,0)]
+                return [Rayf(PI,S3,ri.intensity, ri.wavelength, ni, ri.label, ri.draw_color, None ,0,self.id,0)]
 
     cpdef pw_propagate1(self, Ray ri,ni,nr, rsamples, isamples, knots):
         '''Method to calculate wavefront emerging from the surface
-        
+
         .. Note::
-            This method needs to be checked, because the incoming plane 
-            wave has not a constant intensity. The ray distribution is 
-            affected by the surface topography. it is better to use the 
+            This method needs to be checked, because the incoming plane
+            wave has not a constant intensity. The ray distribution is
+            affected by the surface topography. it is better to use the
             slow version pw_propagate.
 
         This method calculates the wavefront emerging from the optical surface
-        when illuminated by an unity amplitude plane wave. 
-        The k vector of the incoming PW is given by the direction of ri. 
+        when illuminated by an unity amplitude plane wave.
+        The k vector of the incoming PW is given by the direction of ri.
         The wavelength of the PW is given by the wavelength of ri.
         The origin of ri is not used at all.
-       
-        The input and output planes are located at z=0 in the surface coordinated 
-        system. 
-        
+
+        The input and output planes are located at z=0 in the surface coordinated
+        system.
+
         Note: this method needs to be checked, because the incoming plane wave
-        has not a constant intensity. The ray distribution is affected by the 
+        has not a constant intensity. The ray distribution is affected by the
         surface topography. it is better to use the slow version pw_propagate1.
-        
+
         Note: The ray comes from the negative side. Need to change this
-        
+
         Arguments:
-        
+
 
              ri -- isurface.pyncident ray
-             
+
              ni -- refraction index in the incident media n.
-             
+
              nr -- refraction index in the refracted media
 
         ri must be in the coordinate system of the surface
         '''
-         
+
         # Calculate the position maximum and minimum z values for the surface
         X, Y, Z=self.shape.mesh(topo=self.topo)
-        
+
         #Calculate a mesh where the test rays will be shot from
         X, Y, H=self.shape.mesh(ndat=rsamples)#,  size=(xmin, xmax, ymin, ymax))
         X, Y, Z=self.shape.mesh(ndat=rsamples,  topo=self.topo)
 
-        
-        
+
+
         # The ecuation where the rays are shooted to is Z=0
         N_=array((0, 0, 1))
-        
+
         # The ecuation where the rays are shooted from is
         # X*dx+Y*dy+Z*dz=0, where dx,dy,dx are the plane normal.
         N_p=ri.dir
-        
+
         ix, iy=indices(X.shape)
-        
-        # Create a list of indexes to be able to select the points that are going 
+
+        # Create a list of indexes to be able to select the points that are going
         # to be used as spline generators, and as control points
         idx=where((ix+iy) %2 ==0, False, True)
-        
+
         X=X.flatten()
         Y=Y.flatten()
         Z=Z.flatten()
@@ -598,43 +598,43 @@ cdef class Surface(Picklable):
         yi=[]
         zi=[]
         ii=[]
-        
+
         for i in li:
             #Destination of the ray
             P1=array((X[i], Y[i], Z[i]))
-            
+
             #Normal to the destination point
             Np=self.normal(P1)
-            
-            # Calculate incident and refracted angle. To optimize the routine, 
+
+            # Calculate incident and refracted angle. To optimize the routine,
             # only normal diffracted ray is taken into account
-            
+
             # Calculate the incident angle
             I=(arccos(dot(S1,Np)/ni))
-            
+
             # Take the correct normal
             if I>pi/2:
                 Np=-Np
                 I=(arccos(dot(S1,Np)/ni))
             # Calculate the diffracted direction
-            
+
             gamma= nr*sqrt(power(ni/nr*cos(I),2)-power(ni/nr,2)+1.)- ni*cos(I)
             A=gamma*Np
             S2=nr*(S1+A)
             L2=(S2/sqrt(dot(S2,S2)))
-            ###  
-            
-            # Calculate the distance between P1 ant the plane X*dx+Y*dy+Z*dz=0, 
+            ###
+
+            # Calculate the distance between P1 ant the plane X*dx+Y*dy+Z*dz=0,
             # along the N_p direction
             din=-dot(N_p,-P1)
-            
+
             # Calculate the distance between P1 Z=0 along the L2 line
             ddi=-P1[2]/L2[2]
-            
+
             #Calculate the intersection point
             PIR=P1+ddi*L2
 
-            
+
             # Calculate optical path
             d=din*ni+ddi*nr
             if d!=inf:
@@ -642,170 +642,170 @@ cdef class Surface(Picklable):
                 xi.append(x)
                 yi.append(y)
                 zi.append(d)
-                ii.append(idx[i])    
+                ii.append(idx[i])
         xi=array(xi)
         yi=array(yi)
         zi=array(zi)
         ii=array(ii)
-        
+
         xmax=xi.max()#=abs(array(xi+yi)).max()
         ymax=xmax
         xmin=xi.min()#-ymax
         ymin=xmin#-xmax
-        
+
         xx=linspace(xmin, xmax, isamples[0])
         yy=linspace(ymin, ymax, isamples[1])
-        
-        # Use only half of the samples to create the Spline, 
+
+        # Use only half of the samples to create the Spline,
         isp=argwhere(ii==True)
         ich=argwhere(ii==False)
-        
+
         xsp=xi[isp]
         ysp=yi[isp]
         zsp=zi[isp]
-        
+
         xch=xi[ich]
         ych=yi[ich]
         zch=zi[ich]
-        
+
         #Distribute homogeneously the knots
         xk=linspace(xsp.min(), xsp.max(),knots)
         yk=linspace(ysp.min(), ysp.max(),knots)
-        
-        # LSQBivariateSpline using some knots gives smaller error than 
+
+        # LSQBivariateSpline using some knots gives smaller error than
         # SmoothBivariateSpline
         di=interpolate.LSQBivariateSpline(xsp, ysp, zsp, xk[1:-1],  yk[1:-1])
         #di=interpolate.SmoothBivariateSpline(xsp, ysp, zsp)
-        
+
         # Evaluate error
         zch1=di.ev(xch, ych)
         er=(zch.flatten()-zch1).std()
-        
+
         #I, xe, ye=histogram2d(yi, xi, (xx, yy))
         I=hitlist2int(xi, yi, xi,  xx, yy)
         d=ma_array(di(xx,yy).transpose(), mask=I.mask)
-        
+
         #XD, YD=meshgrid(xx, yy)
-        
+
         #d1=griddata(xi,  yi,  zi,  xx, yy)
         return I, d, er
-        
-        
-    
+
+
+
     cpdef pw_propagate(self, Ray ri,ni,nr, rsamples, shape, order,z):
         '''Method to calculate wavefront emerging from the surface
 
 
         This method calculates the wavefront emerging from the optical surface
-        when illuminated by an unity amplitude plane wave. 
-        The k vector of the incoming PW is given by the direction of ri. 
+        when illuminated by an unity amplitude plane wave.
+        The k vector of the incoming PW is given by the direction of ri.
         The wavelength of the PW is given by the wavelength of ri.
         The origin of ri is not used at all.
-               
+
         Arguments:
-        
+
 
              ri -- surface incident ray
-             
+
              ni -- refraction index in the incident media n.
-             
+
              nr -- refraction index in the refracted media
-             
+
              rsamples -- number of rays used to sample the surface
-             
+
              shape -- shape of the output wavefront
-             
+
              order -- order of the polynomial fit
-             
+
              z -- Z position of the input and output plane. The origin is the surface vertex
 
         ri must be in the coordinate system of the surface
         Note: The ray comes from the negative side. Need to change this
         '''
         from ray_trace.surface import Plane
-        
+
         xi,yi,zi=self.pw_propagate_list(ri,ni,nr,rsamples,z)
-    
+
         xmin,xmax,ymin,ymax=self.shape.limits()
         xx=linspace(xmin, xmax, shape[0])
         yy=linspace(ymin, ymax, shape[1])
-        
+
         #I, xe, ye=histogram2d(yi, xi, (xx, yy))
         I=hitlist2int(xi, yi, xi,  xx, yy)
 
-        
+
         p,er=polyfit2d(xi, yi, zi,order=order)
-        
+
         d=ma_array(p.evalvv(xx,yy),mask=I.mask)
         #d,er=interpolate_g(xi,yi,zi,xx,yy,knots=knots, error=True,mask=I.mask)
-        
+
         #XD, YD=meshgrid(xx, yy)
 
         #d1=griddata(xi,  yi,  zi,  xx, yy)
         return I, d, er
-        
+
     cpdef pw_propagate_list(self, Ray ri,ni,nr, rsamples,z):
         '''Method to calculate wavefront emerging from the surface
 
-        This method calculates samples of the  wavefront emerging from 
-        the optical surface when illuminated by an unity amplitude plane 
-        wave. 
-        The k vector of the incoming PW is given by the direction of ri. 
+        This method calculates samples of the  wavefront emerging from
+        the optical surface when illuminated by an unity amplitude plane
+        wave.
+        The k vector of the incoming PW is given by the direction of ri.
         The wavelength of the PW is given by the wavelength of ri.
         The origin of ri is not used at all.
-        
+
         The returned value is a list containing the x,y coordinates of the ray list
         in the output surface, and the optical path at such point.
-        
+
         To create an output matrix, this values must be interpolated.
-        
-        
-               
+
+
+
         Arguments:
-        
+
 
              ri -- incident ray
-             
+
              ni -- refraction index in the incident media n.
-             
+
              nr -- refraction index in the refracted media
-             
+
              rsamples -- number of rays used to sample the surface (Tuple)
-             
+
              z -- Z position of the input and output plane. The origin is the surface vertex
 
         ri must be in the coordinate system of the surface
         Note: The ray comes from the negative side. Need to change this
         '''
         from pyoptools.raytrace.surface import Plane
-        
-        #plane where the aperture is located 
+
+        #plane where the aperture is located
         Za=z
-        
+
         # Create an array of rays to simulate the plane wave
         dir=ri.dir
         xmin,xmax,ymin,ymax=self.shape.limits()
-        
+
         # Calculate the position maximum and minimum z values for the surface
         #X, Y, H=self.shape.mesh(ndat=rsamples)
         #X, Y, H=self.shape.mesh(ndat=rsamples)
 
-        
-        #X;Y;Z coordinates of the points the rays are aiming to  in the 
+
+        #X;Y;Z coordinates of the points the rays are aiming to  in the
         # aperture plane. The 20% increase in size, is to assure that
         # all the surface is sampled even if the rays are tilted
         dx=float(xmax-xmin)*.1
         dy=float(ymax-ymin)*.1
-        
+
         Xa=linspace(xmin-dx, xmax+dx,int(rsamples[0]*1.2))
         Ya=linspace(ymin-dy, ymax+dy,int(rsamples[1]*1.2))
         #print Xa,Ya
         Xa,Ya=meshgrid(Xa,Ya)
-      
+
         #
         Xa=Xa.flatten()
-        Ya=Ya.flatten()  
-        
+        Ya=Ya.flatten()
+
         # The ecuation where the rays are shooted from is
         # X*dx+Y*dy+Z*dz=0, where dx,dy,dx are the plane normal.
         Z=-(Xa*dir[0]+Ya*dir[1])/dir[2]+Za
@@ -817,26 +817,26 @@ cdef class Surface(Picklable):
         yi=[]
         zi=[]
         for i in range(len(Xa)):
-                     
+
             P0=array((Xa[i],Ya[i],Z[i]))
-            
+
             ri=Ray(pos=P0,dir=dir,wavelength=ri.wavelength)
             #if the ray do not intersect the surface, break current iteration
             if sometrue(npisinf(self.intersection(ri))): continue
-            
+
             #print self.intersection(ri)
             rd=self.propagate(ri,ni,nr)
-          
+
             #take only the transmitted ray
             rd=rd[0]
-            
+
             #Translate rd, to put it in the aperture reference plane
             rd.pos[2]=rd.pos[2]-Za
             di=self.distance_s(ri)[0]
             dr=pl.distance_s(rd)[0]
-            
+
             PI=pl._intersection(rd)
-            
+
             # Calculate optical path
             d=di*ni+dr*nr
             #print d,di,dr,PI
@@ -848,31 +848,31 @@ cdef class Surface(Picklable):
         xi=array(xi)
         yi=array(yi)
         zi=array(zi)
-        
+
         return xi,yi,zi
-        
-            
-        
+
+
+
     cpdef wf_propagate(self, wf,ni,nr, samples,shape, knots):
         '''Method to calculate wavefront emerging from the surface
 
 
         This method calculates the wavefront emerging from the optical surface
         when illuminated by an arbitrary wavefront.
-              
-        The input and output planes are located at z=0 in the surface coordinated 
-        system. 
-        
+
+        The input and output planes are located at z=0 in the surface coordinated
+        system.
+
         Arguments:
-        
+
              wf -- Field instance containing the incoming wavefront
-             
+
              ni -- refraction index in the incident media n.
-             
+
              nr -- refraction index in the refracted media.
-             
+
              samples -- Tuple containing the number of rays used to sample the field.
-             
+
              shape -- Tuple containing the shape of the output field
         '''
         from ray_trace.surface import Plane
@@ -880,33 +880,33 @@ cdef class Surface(Picklable):
         # TODO: This representation only takes into account the phase, but not the intensity.
         #       This has to be fixed, because in practice this is not OK
         rays=wf.rayrep(samples[0],samples[1])
-        
+
         #TODO: check which rays pass inside the aperture
-        
+
         #rin=Ray( dir=L1, wavelength=wavelength)
-        
+
         #Intersection point and optical path for the incident rays
 
         xi=[]
         yi=[]
         zi=[]
-    
+
         pl=Plane()
         for ri in rays:
             #Calculate the intersection point
             rd=self.propagate(ri,ni,nr)
             #Take only de transmitted ray
             rd=rd[0]
-            
+
             # Incident ray propagation distance until the optical surface
             di=self.distance(ri)[0]
-            
-            
-            
+
+
+
             # Refracted ray propagation until the output surface (plane Z=0)
             # The distance method is not used, because it eliminates the negative
             # propagation values
-            
+
             PI=pl._intersection(rd)
             dr=dot(PI-rd.pos,rd.dir)
 
@@ -919,130 +919,130 @@ cdef class Surface(Picklable):
                 zi.append(d)
             else:
                 print ri
-                
+
         d=interpolate_g(xi,yi,zi,samples=shape,knots=knots, error=False,mask=None)
-        
+
         return d
-        
+
     def __repr__(self):
         #~ '''Return an string with the representation of the optical surface
-#~ 
+#~
         #~ It must be overloaded in all subclasses
         #~ '''
 
         return "OptSurf(reflectivity="+str(self.reflectivity)+")"
 
-    
 
-    
+
+
     cpdef reset(self):
         ''' Remove information from the hit_list
         '''
         self._hit_list=[]
-        
-        
+
+
     cpdef pw_cohef(self,ni,nr,ilimit, slimit, step, order, rsamples,zb):
-        '''Method to generate the taylor polinomial coheficients that can be 
-        used to obtain the phase and intensity for different plane wave 
+        '''Method to generate the taylor polinomial coheficients that can be
+        used to obtain the phase and intensity for different plane wave
         inclinations.
-     
-        Notes: 
+
+        Notes:
                - The pupil is normalized to the radius of the lens
                - This method assumes a circular shaped pupil
                - The phase is returned as an optical path
                - The intensity is normalized to 1
-               
+
         Arguments:
-        
-        =========  ======================================================        
+
+        =========  ======================================================
         ni,nr      Refraction index from the incident and refracted sides
-        ilimit     Inferior limit for incidence angle of the plane wave 
+        ilimit     Inferior limit for incidence angle of the plane wave
                    in radians
-        slimit     Superior limit for incidence angle of the plane wave 
+        slimit     Superior limit for incidence angle of the plane wave
                    in radians
         step       Step to be used to generate the interpolation data
         order      Order of the Taylor interpolation used
-        rsamples   Tuple containing the number of ray samples to be used 
+        rsamples   Tuple containing the number of ray samples to be used
                    in each direction
-        zb         Z position of the plane where the measurementas are 
-                   made. The origin is the vertex of the surface. If 
+        zb         Z position of the plane where the measurementas are
+                   made. The origin is the vertex of the surface. If
                    None, an estimate position is taken.
-        =========  ======================================================  
-        
+        =========  ======================================================
+
         '''
         xm=self.shape.limits()[1]
         #print xm
         #Get the z position of the border of the surface
-        
+
         if zb == None:
             zm=self.topo(xm,0)
         else: zm=zb
-        
-        # Optical path coheficient list 
+
+        # Optical path coheficient list
         opcl=[]
-        
+
         # Intensity coheficient list
         icl=[]
-        
+
         xd=[]
         for i in arange(ilimit,slimit,step):
             xd.append(i)
-            
+
             x,y,d =self.pw_propagate_list(Ray(dir=(tan(i), 0, 1)),ni,nr, rsamples=rsamples,z=zm)
-            
+
             #Normalize the pupil
             x=x/xm; y=y/xm
-            
+
             # Get the optical path polynomial coheficients
             pf,ef=polyfit2d(x, y, d,order=order)
-            
+
             #get the intensity data
             xi,yi,I= hitlist2int_list(x, y)
-            
+
             # Get the intensity polynomial coheficients
             pi,ei=polyfit2d(xi, yi, I,order=order)
-            
-            #TODO: Print something if error is too big 
+
+            #TODO: Print something if error is too big
             #if ei>0.001: print ""
             #if ef>1e-6: print ""
-            
+
             opcl.append(pf.cohef.flatten())
 
-            icl.append(pi.cohef.flatten())    
+            icl.append(pi.cohef.flatten())
 
         dph=array(opcl)
         di=array(icl)
 
         # Lista de los coheficientes de los polinomios para generar los coheficientes
-        phcohef=[] 
-        
+        phcohef=[]
+
         #get the number of coheficients the polinomial expansion has
         ncohef=ord2i(order)
-        
+
         for i in range(ncohef):
             #figure()
             #plot(xd,d[:,i])
             pof=polyfit(xd,dph[:,i],15)
             phcohef.append(pof)
-        
+
         icohef=[]
-        
+
         for i in range(ncohef):
             #figure()
             #plot(xd,d[:,i])
             pof=polyfit(xd,di[:,i],15)
             icohef.append(pof)
-        
-        return phcohef, icohef, zm 
-        
-    
+
+        return phcohef, icohef, zm
+
+
     def polylist(self):
-        
+
         points=[]
-        
+
         X,Y=self.shape.pointlist()
         Z=self.topo(X,Y)
-        
+
         for i in range(len(X)):
             points.append((X[i],Y[i],Z[i]))
 
@@ -1050,4 +1050,3 @@ cdef class Surface(Picklable):
         tri=Triangulation(X,Y)
         trip=tri.triangles
         return points, trip
-        


### PR DESCRIPTION
Typically moulded aspheric lenses are specified by an aspheric surface with a radially symmetric function.
While a general 2D aspheric surface is available, this is not very helpful for modelling these lenses.

This pull request adds a new aspheric lens component type and the necessary surface functions for defining radially-symmetric polynomials. Lenses with either one or two aspheric surfaces are supported. Lenses with a flat brim around the primary surfaces are supported since this is common with moulded aspheres. Lenses can be constructed with the origin point optionally set to the center or either side of a given aspheric surface with a descriptor string.

Apologies for the changes showing up which are just removals of trailing whitespace. My editor has done this on saving. I would suggest a separate commit at some point to remove trailing whitespace from all files for pep8 compliance. 