### PR TITLE
use `jupyter notebook` instead of `ipython notebook`

### DIFF
--- a/ipyoptools
+++ b/ipyoptools
@@ -1,4 +1,4 @@
 #/bin/sh
 export PYOPENGL_PLATFORM=osmesa
 #ipython notebook --pylab=inline
-ipython notebook
+jupyter notebook


### PR DESCRIPTION
Fixes this warning:
```
[TerminalIPythonApp] WARNING | Subcommand `ipython notebook` is deprecated
[TerminalIPythonApp] WARNING | You likely want to use `jupyter notebook` in the future
```
