### PR TITLE
Tutorial fix

### DIFF
--- a/Tutorial/Tutorial.1.ipynb
+++ b/Tutorial/Tutorial.1.ipynb
@@ -15,23 +15,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading component library Edmund  from files  ['/usr/lib/python3/dist-packages/pyoptools/raytrace/library/Edmund/SphOptics.cmp', '/usr/lib/python3/dist-packages/pyoptools/raytrace/library/Edmund/SphOptics1.cmp']\n",
-      "Loading component library Thorlabs  from files  ['/home/richi/.pyoptools/library/Thorlabs/SphOptics1.cmp']\n",
-      "Loading component library EdmundHome  from files  ['/home/richi/.pyoptools/library/EdmundHome/SphOptics.cmp']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Import pyoptools to load all contents\n",
     "\n",
-    "from pyoptools.all import *"
+    "from pyoptools.all import *\n",
+    "from math import pi"
    ]
   },
   {
@@ -160,24 +151,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fbe6a18e5025465e9ea4d791a66277fb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-180.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Example 2.1 : Plane surfaces\n",
     "\n",
@@ -204,24 +180,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d587aef70daa47c1a90c84a1da530dcf",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-200.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 2.2: Spherical surface\n",
     "\n",
@@ -253,24 +214,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b80e68f7aca34ee6aaffd7729a1dd294",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-150.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 2.3: Circular cilynders with different shapes\n",
     "\n",
@@ -304,17 +250,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1.0+2.0x+3.0y+4.0x^2+5.0xy+y^2+7.0x^3+8.0x^2y+9.0xy^2+10.0y^3+11.0x^4+12.0x^3y\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 2.4  poly2d in pyOpyools\n",
     "\n",
@@ -324,24 +262,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "12ba3bb2808d45afbbac3c6d3fc1b1ab",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-160.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 2.5 Symmetric aspherical surface\n",
     "\n",
@@ -420,38 +343,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6800d7dd80ae40a8b421dd5a31e291fa",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-100.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "803d4e8efa13420281b5aa9bef45c1f0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-100.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 3.1: Building an equilateral prism and a cylindrical lens\n",
     "from math import *\n",
@@ -474,7 +368,7 @@
     "                      (T1,(L/2,0,0),(0,pi/2,0)),\n",
     "                      (T2,(-L/2,0,0),(0,pi/2,0))\n",
     "                      ], \n",
-    "                      material=material.schott[\"BK7\"])\n",
+    "                      material=material.schott[\"N-BK7\"])\n",
     "\n",
     "## Cylindrical lens\n",
     "\n",
@@ -484,7 +378,7 @@
     "L=Component(surflist=[(S5,(0,0,5),(0,0,pi/2)),\n",
     "                      (S4,(0,0,-5),(0,0,pi/2))\n",
     "                      ], \n",
-    "                      material=material.schott[\"BK7\"])\n",
+    "                      material=material.schott[\"N-BK7\"])\n",
     "\n",
     "display(Plot3D(P,center=(0,0,0),size=(150,100),scale=2,rot=[(0,pi/2+.2,0),(-.1,0,0)]))\n",
     "Plot3D(L,center=(0,0,0),size=(150,100),scale=2,rot=[(0,pi/2.2,0),(0,0,0)])"
@@ -538,24 +432,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "86bead14d2dc4fa2a0f15b1714d69b6a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-175.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 3.2 Visualization of an air spaced doublet\n",
     "\n",
@@ -613,24 +492,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "43da2f1f1c4341a487ef03b6e9b3a9a1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-100.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 3.3 Visulization of a rectangular thick mirror.\n",
     "\n",
@@ -667,30 +531,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5569c8ca563a4102b9939474ecb916f2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-150.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 3.4 Visulization of a beamsplitter\n",
     "\n",
-    "BS=BeamSplitingCube(size=20, reflectivity=0.5, material=material.schott[\"BK8\"])\n",
+    "BS=BeamSplitingCube(size=20, reflectivity=0.5, material=material.lzos[\"BK8\"])\n",
     "\n",
     "\n",
     "Plot3D(BS,center=(0,0,0),size=(50,50),rot=[(pi/4,0,0)],scale=6)"
@@ -736,31 +585,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bcd0a324cd0f42e5bf51c50e1e5fbbe2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-150.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Example 4.1: Visualization of 2 predefined lenses and a CCD\n",
     "\n",
-    "L2=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"BK7\"])\n",
-    "L3=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"BK7\"])\n",
+    "L2=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"N-BK7\"])\n",
+    "L3=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"N-BK7\"])\n",
     "\n",
     "C=CCD()\n",
     "\n",
@@ -820,26 +654,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9dd971a24f0a47c8b77875f68b03ca54",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-150.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Example 4.2  Visualization of a default parallel beam\n",
     "\n",
@@ -863,29 +682,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4b500b1d6c6a4a43bcb3e7af61e9382d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-200.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 4.3 : Ray tracing for the optical system of the example 4.1\n",
     "\n",
-    "L1=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"BK7\"])\n",
-    "L2=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"BK7\"])\n",
+    "L1=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"N-BK7\"])\n",
+    "L2=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"N-BK7\"])\n",
     "\n",
     "CSys=CCD()\n",
     "\n",
@@ -900,24 +704,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "701459fbea514b9287b71fe5a89915c8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-200.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "## Example 4.4 : Spectroscope using the components from the example 3.1\n",
     "\n",
@@ -940,7 +729,7 @@
     "                      (T1,(L/2,0,0),(0,pi/2,0)),\n",
     "                      (T2,(-L/2,0,0),(0,pi/2,0))\n",
     "                      ], \n",
-    "                      material=material.schott[\"BK7\"])\n",
+    "                      material=material.schott[\"N-BK7\"])\n",
     "\n",
     "S4=Cylindrical(shape=Circular(radius=25),curvature=1./200)\n",
     "S5=Cylindrical(shape=Circular(radius=25),curvature=-1./200)\n",
@@ -949,7 +738,7 @@
     "L=Component(surflist=[(S5,(0,0,5),(0,0,pi/2)),\n",
     "                      (S4,(0,0,-5),(0,0,pi/2))\n",
     "                      ], \n",
-    "                      material=material.schott[\"BK7\"])\n",
+    "                      material=material.schott[\"N-BK7\"])\n",
     "\n",
     "# CCD and optical system\n",
     "CSpect=CCD()\n",
@@ -1020,79 +809,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "([0.4565802759425903,\n",
-       "  -0.45658027594258765,\n",
-       "  1.8124557397722256,\n",
-       "  -0.20643383967222118,\n",
-       "  0.20643383967222206,\n",
-       "  -1.8124557397722256,\n",
-       "  1.058982857694712,\n",
-       "  -0.39588193357762425,\n",
-       "  0.39588193357762336,\n",
-       "  -1.058982857694712,\n",
-       "  1.8124557397722256,\n",
-       "  -0.20643383967222118,\n",
-       "  0.20643383967222206,\n",
-       "  -1.8124557397722256,\n",
-       "  0.4565802759425903,\n",
-       "  -0.45658027594258765],\n",
-       " [-1.3886103716386202,\n",
-       "  -1.3886103716386202,\n",
-       "  -0.9150187845717763,\n",
-       "  0.31087134222859625,\n",
-       "  0.31087134222859625,\n",
-       "  -0.9150187845717763,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.9150187845717763,\n",
-       "  -0.31087134222859625,\n",
-       "  -0.31087134222859625,\n",
-       "  0.9150187845717763,\n",
-       "  1.3886103716386202,\n",
-       "  1.3886103716386202],\n",
-       " [220.85950385653626,\n",
-       "  220.85950385653626,\n",
-       "  221.00077938937272,\n",
-       "  220.49883328696868,\n",
-       "  220.49883328696868,\n",
-       "  221.00077938937272,\n",
-       "  220.7661279552741,\n",
-       "  220.4943566553792,\n",
-       "  220.4943566553792,\n",
-       "  220.7661279552741,\n",
-       "  221.00077938937272,\n",
-       "  220.49883328696868,\n",
-       "  220.49883328696868,\n",
-       "  221.00077938937272,\n",
-       "  220.85950385653626,\n",
-       "  220.85950385653626])"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAD8CAYAAAB+UHOxAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAENdJREFUeJzt3XGMHOddxvHnsZ30dIBowVc7tX2+VFhVUmgorK1E+afQBHyRFRNoJEcWpCLVqeAIkEAiaCWoIp1UhAQSjUV6baKkaGlaFUyMmpWbtEVBalN5r3JDHDetsbBzcuxcEkiDrkfl5scfs5bPZvdu72a8s7Pv9yOdZt93X8/720lunpud2VlHhAAA6VlXdgEAgHIQAACQKAIAABJFAABAoggAAEgUAQAAiSIAACBRBAAAJKqQALD9qO1Xbb/Q5fkP2X7T9rH2z58XMS8AYO02FLSexyQ9JOlzy4z5t4jYs5qVbty4MSYmJnKUBQBpmZ2dfS0ixnoZW0gARMSztieKWNdSExMTarVaRa8WAIaW7dO9ju3nOYBbbH/HdtP2+7sNsj1lu2W7NT8/38fyACAt/QqAb0vaHhE3SfqUpH/uNjAiZiKiFhG1sbGejmIAAGvQlwCIiB9ExP+0Hz8l6RrbG/sxNwCgs74EgO3Ntt1+vKs97+v9mBsA0FkhJ4Ftf17ShyRttD0n6S8kXSNJEfGwpI9I+j3bFyT9UNK+4IsIAKBUhRwBRMQ9EXFdRFwTEVsj4pGIeLi981dEPBQR74+ImyLi5oj4RhHzIi2NpjSxR1q3M1s2mmVX1H9sAxSpqM8BAFdVoylNTUsLi1n79LmsLUn7J8urq5/YBigat4JAJdQPXtrxXbSwmPWngm2AohEAqIQz51fXP4zYBigaAYBKGN+0uv5hxDZA0QgAVML0AWl05PK+0ZGsPxVsAxSNAEAl7J+UZurS9s2SnS1n6mmd/GQboGge5Mvxa7VacDM4AOid7dmIqPUyliMAAEgUAQAAiSIAACBRBAAAJIoAAIBEEQAAkCgCAAASRQAAQKIIAABIFAEAAIkiAAAgUQQAACSKAACARBEAAJAoAgAAEkUAAECiCAAASBQBAACJIgAAIFGFBIDtR22/avuFLs/b9t/aPmn7edu/VMS8AIC1K+oI4DFJu5d5flLSjvbPlKS/K2heAMAaFRIAEfGspDeWGbJX0uci85ykd9q+roi5AQBr069zAFskvbykPdfuAwCUpF8B4A590XGgPWW7Zbs1Pz9/lcsCgHT1KwDmJG1b0t4q6WyngRExExG1iKiNjY31pTgASFG/AuCwpN9pXw10s6Q3I+KVPs0NAOigqMtAPy/pm5LeZ3vO9n22P2774+0hT0k6JemkpM9I+v0i5u23RlOa2COt25ktG82yKwLQb8O0H9hQxEoi4p4Vng9JB4qYqyyNpjQ1LS0sZu3T57K2JO2fLK8uAP0zbPsBPgnco/rBS//RL1pYzPoBpGHY9gMEQI/OnF9dP4DhM2z7AQKgR+ObVtcPYPgM236AAOjR9AFpdOTyvtGRrB9AGoZtP0AA9Gj/pDRTl7ZvluxsOVOv5okfAGszbPsBZxfoDKZarRatVqvsMgCgMmzPRkStl7EcAQBAoggAAEgUAQAAiSIAACBRBAAAJIoAAIBEEQAAkCgCAAASRQAAQKIIAABIFAEAAIkiAAAgUQQAACSKAACARBEAAJAoAgAAEkUAAECiCAAASBQBAACJIgAAIFEEAAAkqpAAsL3b9ku2T9p+oMPzH7U9b/tY++djRcwLAFi7DXlXYHu9pIOSbpc0J+mo7cMR8eIVQ78QEffnnQ8AUIwijgB2SToZEaci4keSnpC0t4D1AgCuoiICYIukl5e059p9V/ot28/b/pLtbd1WZnvKdst2a35+voDyAACdFBEA7tAXV7T/RdJERHxA0jOSHu+2soiYiYhaRNTGxsYKKA8A0EkRATAnaelf9FslnV06ICJej4j/bTc/I+mXC5gXAJBDEQFwVNIO29fbvlbSPkmHlw6wfd2S5p2SThQwLwAgh9xXAUXEBdv3Szoiab2kRyPiuO0HJbUi4rCkP7B9p6QLkt6Q9NG88wIA8nHElW/XD45arRatVqvsMgCgMmzPRkStl7F8EhgAEkUAAECiCAAASBQBAACJIgAAIFEEAJLTaEoTe6R1O7Nloznc8wLd5P4cAFAljaY0NS0tLGbt0+eytiTtnxy+eYHlcASApNQPXtoJX7SwmPUP47zAcggAJOXM+dX1V31eYDkEAJIyvml1/VWfF1gOAYCkTB+QRkcu7xsdyfqHcV5gOQQAkrJ/UpqpS9s3S3a2nKlf/ROxZc0LLIebwQHAEOFmcACAFREAAJAoAgAAEkUAAECiCAAASBQBAACJIgAAIFEEAAAkigAAgEQRAACQKAIAABJFAABAoggAAEhUIQFge7ftl2yftP1Ah+ffYfsL7ee/ZXuiiHkBAGuXOwBsr5d0UNKkpBsl3WP7xiuG3SfpvyLi5yT9jaS/zDsvitNoShN7pHU7s2WjWXZFvaty7b2o8uurcu2p2FDAOnZJOhkRpyTJ9hOS9kp6ccmYvZI+0X78JUkP2XYM8pcRJKLRlKamL31h+elzWVsa/C8rqXLtvajy66ty7Skp4i2gLZJeXtKea/d1HBMRFyS9KelnC5gbOdUPXvolvWhhMesfdFWuvRdVfn1Vrj0lRQSAO/Rd+Zd9L2OygfaU7Zbt1vz8fO7isLwz51fXP0iqXHsvqvz6qlx7SooIgDlJ25a0t0o6222M7Q2SflrSG51WFhEzEVGLiNrY2FgB5WE545tW1z9Iqlx7L6r8+qpce0qKCICjknbYvt72tZL2STp8xZjDku5tP/6IpK/x/v9gmD4gjY5c3jc6kvUPuirX3osqv74q156S3CeBI+KC7fslHZG0XtKjEXHc9oOSWhFxWNIjkv7e9kllf/nvyzsvinHxhFz9YHZ4Pr4p+yWtwom6Ktfeiyq/virXnhIP8h/itVotWq1W2WUAQGXYno2IWi9j+SQwACSKAACARBEAAJAoAgAAEkUAAECiCAAASBQBAACJIgAAIFEEAAAkigAAgEQRAACQKAIAABJFAABAoggAAEgUAYDkNJrSxB5p3c5s2WgO97xAN7m/EAaokkZTmpq+9IXlp89lbenqfllJWfMCy+EIAEmpH7y0E75oYTHrH8Z5geUQAEjKmfOr66/6vMByCAAkZXzT6vqrPi+wHAIASZk+II2OXN43OpL1D+O8wHIIACRl/6Q0U5e2b5bsbDlTv/onYsuaF1iOI6LsGrqq1WrRarXKLgMAKsP2bETUehnLEQAAJIoAAIBEEQAAkCgCAAASRQAAQKJyBYDtn7H9tO3vt5fv6jLux7aPtX8O55kTAFCMvEcAD0j6akTskPTVdruTH0bEL7Z/7sw5JwCgAHkDYK+kx9uPH5f0GznXBwDok7wBsCkiXpGk9vLdXcaN2G7Zfs42IQEAA2DF7wOw/YykzR2eqq9invGIOGv7vZK+ZvvfI+I/usw3JWlKksbHx1cxBQBgNVYMgIi4rdtzts/bvi4iXrF9naRXu6zjbHt5yva/SvqgpI4BEBEzkmak7FYQK74CAMCa5H0L6LCke9uP75X05JUDbL/L9jvajzdKulXSiznnBQDklDcAPinpdtvfl3R7uy3bNdufbY+5QVLL9nckfV3SJyOCAACAkuX6TuCIeF3Shzv0tyR9rP34G5J+Ic88AIDi8UlgAEgUAQAAiSIAACBRBAAAJIoAAIBEEQAAkCgCAAASRQAAQKIIAABIFAEAAIkiAAAgUQQAACSKAACARBEAAJAoAgAAEkUAAECiCAAASBQBAACJIgAAIFEEAAAkigAAgEQRAKvQaEoTe6R1O7Nlo1l2RQD6bZj2AxvKLqAqGk1palpaWMzap89lbUnaP1leXQD6Z9j2AxwB9Kh+8NJ/9IsWFrN+AGkYtv0AAdCjM+dX1w9g+AzbfoAA6NH4ptX1Axg+w7YfIAB6NH1AGh25vG90JOsHkIZh2w/kCgDbd9s+bvtt27Vlxu22/ZLtk7YfyDNnWfZPSjN1aftmyc6WM/VqnvgBsDbDth9wRKz9H9s3SHpb0qcl/UlEtDqMWS/pe5JulzQn6aikeyLixZXWX6vVotX6f6sEAHRhezYiuv5BvlSuy0Aj4kR7wuWG7ZJ0MiJOtcc+IWmvpBUDAABw9fTjHMAWSS8vac+1+zqyPWW7Zbs1Pz9/1YsDgFSteARg+xlJmzs8VY+IJ3uYo9PhQdf3nSJiRtKMlL0F1MP6AQBrsGIARMRtOeeYk7RtSXurpLM51wkAyKkfbwEdlbTD9vW2r5W0T9LhPswLAFhG3stA77I9J+kWSV+2faTd/x7bT0lSRFyQdL+kI5JOSPpiRBzPVzYAIK+8VwEdknSoQ/9ZSXcsaT8l6ak8cwEAisUngQEgUQQAACSKAACARBEAAJAoAgAAEkUAAECiCAAASBQBAACJIgAAIFEEAAAkigAAgEQRAACQKAIAABJFAABAoggAAEgUAQAAiSIAACBRBAAAJIoAAIBEEQCojEZTmtgjrduZLRvNsivqP7YBipTrS+GBfmk0palpaWExa58+l7Ulaf9keXX1E9sAReMIAJVQP3hpx3fRwmLWnwq2AYpGAKASzpxfXf8wYhugaAQAKmF80+r6hxHbAEUjAFAJ0wek0ZHL+0ZHsv5UsA1QNAIAlbB/UpqpS9s3S3a2nKmndfKTbYCiOSLW/o/tuyV9QtINknZFRKvLuP+U9JakH0u6EBG1XtZfq9Wi1eq4SgBAB7Zne93H5r0M9AVJvynp0z2M/ZWIeC3nfACAguQKgIg4IUm2i6kGANA3/ToHEJK+YnvW9lSf5gQALGPFIwDbz0ja3OGpekQ82eM8t0bEWdvvlvS07e9GxLNd5puSNCVJ4+PjPa4eALBaKwZARNyWd5KIONtevmr7kKRdkjoGQETMSJqRspPAeecGAHR21e8FZPsnJK2LiLfaj39N0oO9/NvZ2dnXbJ++qgVKGyVxcroztk13bJvu2Dbd9WPbbO91YN7LQO+S9ClJY5L+W9KxiPh12++R9NmIuMP2eyUdav+TDZL+ISKm1zxpwWy3er1kKjVsm+7YNt2xbbobtG2T9yqgQ7q0c1/af1bSHe3HpyTdlGceAEDx+CQwACSKAGifcEZHbJvu2DbdsW26G6htk+scAACgujgCAIBEJR8Atv/K9ndtP2/7kO13ll3TILF9t+3jtt+2PTBXL5TF9m7bL9k+afuBsusZJLYftf2q7RfKrmXQ2N5m++u2T7R/n/6w7JokAkCSnpb08xHxAUnfk/RnJdczaC7e8K/jB/dSYnu9pIOSJiXdKOke2zeWW9VAeUzS7rKLGFAXJP1xRNwg6WZJBwbh/53kAyAivhIRF9rN5yRtLbOeQRMRJyLipbLrGBC7JJ2MiFMR8SNJT0jaW3JNA6N9e5c3yq5jEEXEKxHx7fbjtySdkLSl3KoIgCv9rqRm2UVgYG2R9PKS9pwG4JcY1WJ7QtIHJX2r3Er6cCuIQdDLDe1s15UdpjX6WdsgKOiGfynodN9zLqNDz2z/pKR/lPRHEfGDsutJIgBWuqGd7Xsl7ZH04UjwutgibviXiDlJ25a0t0o6W1ItqBjb1yjb+Tci4p/KrkfiLSDZ3i3pTyXdGRELZdeDgXZU0g7b19u+VtI+SYdLrgkV4Oxbsx6RdCIi/rrsei5KPgAkPSTpp5R9T8Ex2w+XXdAgsX2X7TlJt0j6su0jZddUlvbFAvdLOqLsJN4XI+J4uVUNDtufl/RNSe+zPWf7vrJrGiC3SvptSb/a3s8cs31H2UXxSWAASBRHAACQKAIAABJFAABAoggAAEgUAQAAiSIAACBRBAAAJIoAAIBE/R8UFTVGP67TTwAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 4.5:  Recovering the information from the CCD of the example 4.3\n",
     "\n",
@@ -1102,49 +821,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "220.5129748923761+4.5717879650862024e-15x+-9.937393208863556e-15y+0.11358793501737958x^2+-2.2480617568677483e-15xy+0.16184100685712138y^2\n",
-      "Populating the interactive namespace from numpy and matplotlib\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/lib/python3/dist-packages/IPython/core/magics/pylab.py:161: UserWarning: pylab import has clobbered these variables: ['tan', 'isinf', 'sin', 'radians', 'inf', 'isnan', 'frexp', 'exp', 'copysign', 'gcd', 'remainder', 'sqrt', 'cos', 'isfinite', 'fabs', 'trunc', 'expm1', 'e', 'log10', 'poly', 'gamma', 'unwrap', 'cosh', 'nan', 'log1p', 'Polygon', 'hypot', 'pi', 'cross', 'log', 'modf', 'sinh', 'tanh', 'isclose', 'fmod', 'degrees', 'ldexp', 'floor', 'log2', 'ceil']\n",
-      "`%matplotlib` prevents importing * from pylab and numpy\n",
-      "  \"\\n`%matplotlib` prevents importing * from pylab and numpy\"\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.colorbar.Colorbar at 0x7f8f7ccafc18>"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAUQAAAD8CAYAAAAPBN1qAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAHyVJREFUeJzt3X/wXXV95/HnKyFEStAIFISQFopZy4/lRyeLuKxbhBVilgW0ug3TobHIRjpxFjroYGTVTjvM2mGKMy5VmgKLuxMBtxLLaviRocxQdgyaMhEI3wApYE2TkgZUgkDg+/2+9o/z+cL1en+c7703+X6/l9fDOZNzP/dzPvdzILw9n8/nnPOWbSIiAmZNdQciIqaLBMSIiCIBMSKiSECMiCgSECMiigTEiIgiATEiokhAjIgoEhAjIor9proDrew/6wAfMPugqe7GjOG5c2rXnXXU67Xrvnvui710p6ute95eu+74tvrnpj31z+2t7pWx3bw2/or6aePcDxzo518Yq1X37x/Zc4/tJf383r4wLQPiAbMP4n0Hf3SquzFjjB3zrtp1D7h2Z+263150Ty/d6erCp86tXfeVzxxWu+7sZ/65l+68JX3vhb/uu43nXxjj+/f8Wq26s4946tC+f3Af6GvILGmJpCckbZX02Rbfz5V0e/n+IUlH9/N7ETF9GBiv+b9OJC2UdL+kEUmbJV1eyq+VtEXSI5LWSppfyg8p9V+SdH2Hdv+0HLtJ0r2Sjux2Tj0HREmzgb8APgQcD1wk6fimap8AfmL73cCXgT/r9fciYnox5nWP1dq6GAWutH0ccDqwssSS9cCJtk8CngRWlfqvAp8HPt2l3Wttn2T7FOA7wBe6daSfK8TTgK22n7b9GnAbcEFTnQuAr5f9vwbOltTXvEVETB+DuEK0vcP2w2V/NzACLLB9r+3RUm0DcFSp83PbD1IFxk7tNk6CH0h1UdtRP3OIC4AfN3zeBry3XR3bo5J+BhwC7OrjdyNiGjBmbMCvDyzTaqcCDzV9dQlwew/tXQP8PvAz4APd6vdzhdjqSq/5n06dOlVFaYWkjZI2vjb+Sh/dioh9ZRzX2oBDJ/77LtuK5rYkzQO+BVzReHUn6WqqYfWayfbP9tW2F5ZjP9Wtfj9XiNuAhQ2fjwK2t6mzTdJ+wDuAF1o1Zns1sBrgHXMOy1trI6Y5A2PdR6ETdtle3O5LSXOoguEa23c0lC8HzgPOdn9vs/4G8F3gi50q9XOF+ANgkaRjJO0PLAPubKpzJ7C87H8U+Ns+TyoippFJXCG2VdYVbgJGbF/XUL4EuAo43/bLk+2bpEUNH88HtnQ7pucrxDIn+CngHmA2cLPtzZL+BNho+06qk/zfkrZSXRku6/X3ImJ6MfD6YK5vzgAuBh6VtKmUfQ74CjAXWF/WYjfYvgxA0rPA24H9JV0InGP7cUk3AjfY3gh8SdJ7gHHgR8Bl3TrS143ZttcB65rKvtCw/yrwsX5+IyKmJ+PJDJnbt1OtGLdab1jXomzimKPblF/asP87k+3LtHxSJSJmAMPYkE2AJSBGRE+qJ1WGSwJiRPRIjLUc6c5cCYgR0ZNqUSUBMSKi3IeYgBgRAcB4rhAjInKFGBHxBiPGhiwLSQJiRPQsQ+aICKorxNc8e6q7MVAJiBHRk+rG7AyZIyKALKpERABgizHnCjEiAoDxXCFGREwsqgxXCBmus4mIfSaLKhERDcaG7D7E4QrvEbHPTDypUmfrRNJCSfdLGpG0WdLlpfxaSVskPSJpraT5pfyQUv8lSdd3aLfl8Z30HBDbnURTnTMl/UzSprJ9oVVbETEzjXtWra2LUeBK28cBpwMrJR0PrAdOtH0S8CSwqtR/Ffg88Oku7bY7vq1+hswTJ/GwpIOAv5e03vbjTfX+zvZ5ffxORExD1csd+h9k2t4B7Cj7uyWNAAts39tQbQNV5k5s/xx4UNK7u7Tb8vhO+sm61/IkgOaAGBFDyIjXB/zonqSjgVOBh5q+ugS4vY+max0/kDnEDicB8D5JP5R0l6QTBvF7ETH1bBjzrFobcKikjQ3biub2JM2jSlZ/he0XG8qvphqRrumln5M5vu9V5nYnUTwM/LrtlyQtBb4NLGpuo7SzAlgB8LZZ8/rtVkTsdZrMjdm7bC9u25I0hyqOrLF9R0P5cuA84Gx78kmgJ3t8X1eI7U5igu0Xbb9U9tcBcyQd2qot26ttL7a9eP9ZB/TTrYjYB8ykrhDbUpWF/iZgxPZ1DeVLgKuA822/PNn+9XJ8z1eI7U6iqc67gOdsW9JpVAH4+V5/MyKmlwG9IPYM4GLgUUmbStnngK8Ac4H1Vbhhg+3LACQ9C7wd2F/ShcA5th+XdCNwg+2NwPXtjm+nnyFzu5P4NQDbN1Ct6vyhpFHgFWBZL5e9ETH9GA3kBbG2H4SWY+91HY45uk35pQ37HVehW+lnlbndSTTWuZ4qSkfEkKnSkA7Xw27DdTYRsQ8lUX1EBFBe7pD3IUZEVHKFGBFB9cbsXCFGRDCxqJKsexERQHKqREQAE4sqmUOMiAAG9qTKtJGAGBE9GdSTKtNJAmJE9CxJpiIiqN6H+Pp4AmJERBkyJyBGRAB5UiUiAshtNxERDTJkjoh4wyRyqswICYgR0ZNqlXm4nmUeruvdiNhnJm7MrrN1ImmhpPsljUjaLOnyUn6tpC2SHpG0VtL8Un5Iqf+SpLZv5Jf0sdLeuKS2Gf8a9R0QJT0r6VFJmyRtbPG9JH1F0tZyYr/V729GxPQwXlKRdtu6GAWutH0ccDqwUtLxwHrgRNsnAU8Cq0r9V4HPA5/u0u5jwEeAB+qez6CGzB+wvavNdx+iysW8CHgv8LXyZ0TMYINaZba9A9hR9ndLGgEW2L63odoGqqR12P458KCkjkmkbI8AlIx7teyLOcQLgP9Vsu1tkDRf0hHlH0JEzGCTWGU+tGkEudr26uZKko4GTgUeavrqEuD2Hro4KYMIiAbulWTgL1uc5ALgxw2ft5WyBMSIGcwWo/UD4i7bHefxJM0DvgVcYfvFhvKrqYbVa3rta12DCIhn2N4u6TCqhNBbbDeO2Vtdr/5SbmZJK4AVAG+bNW8A3YqIvW1QN2ZLmkMVDNfYvqOhfDlwHnD2vsjp3veiiu3t5c+dwFrgtKYq24CFDZ+PAra3aGe17cW2F+8/64B+uxURe9nEHOIAVpkF3ASM2L6uoXwJcBVwvu2X9+a5TOgrIEo6UNJBE/vAOVQrO43uBH6/rDafDvws84cRw2EQARE4A7gYOKvcrbJJ0lLgeuAgqpHnJkk3TBwg6VngOuDjkraVVWkk3Thxi42kD0vaBrwP+K6ke7p1pN8h8+HA2rKKsx/wDdt3S7oMwPYNwDpgKbAVeBn4gz5/MyKmgUG9INb2g7SeWlvX4Zij25Rf2rC/lmrUWltfAdH208DJLcpvaNg3sLKf34mI6SmP7kVEUD26N5oXxEZEVPL6r4gIkmQqIuIXOAExIqKSRZWICKpFlQyZIyIAEGNZZY6IqGQOMSKCZN2LiHiTq3nEYZKAGBE9yyrzPjA2by67/91vTHU3ZozRt9X/S/mP9x9bu+5vPPLJXrrT1dzn62dqm3/seO26+y3I35m6xv52bt9tOIsqERFvypA5IqLIKnNEBNXVYQJiREQxbLfdDNeMaETsU3a9rRNJCyXdL2lE0mZJl5fyayVtkfSIpLWS5pfyQ0r9lyRd36HdgyWtl/RU+fOd3c4nATEiemLE+PisWlsXo8CVto8DTgdWlhwp64ETbZ8EPAmsKvVfBT4PfLpLu58F7rO9CLivfO4oATEieuaaW8c27B22Hy77u4ERYIHte22PlmobqDJ2YvvnJQ/Lq12avgD4etn/OnBht/PpOSBKek9DhqxNkl6UdEVTnTMl/ayhzhd6/b2ImGbKokqdrS5JRwOnAg81fXUJcNcke3j4RIbP8udh3Q7oeVHF9hPAKQCSZgP/ROsMV39n+7xefyciprH69yEeKmljw+fVtlc3VpA0jypZ/RW2X2wov5pqWL2mv852N6hV5rOBf7D9owG1FxEzwCSu/nbZXtzuS0lzqILhGtt3NJQvB84Dzi4ZPCfjOUlH2N4h6QhgZ7cDBhUQlwG3tvnufZJ+CGwHPm17c6tKklYAKwDmvP2d/PTY+o93vdXNer1+3cM2jnavVMx9YU8Pveluz8H1Hxv76bH1/4qOz+mlN29NY/+v/zYMjI/3f9uNqsTuNwEjtq9rKF8CXAX8tu2Xe2j6TmA58KXy5990O6DvRRVJ+wPnA/+nxdcPA79u+2TgfwDfbteO7dW2F9tePPuAA/vtVkTsbQaseltnZwAXA2c1rDcsBa4HDgLWl7I38r1Leha4Dvi4pG1lVRpJN0qauBL9EvBBSU8BHyyfOxrEFeKHgIdtP9f8ReM8gO11kr4q6VDbuwbwuxExxQbxLHNZMW4VNdd1OOboNuWXNuw/TzWdV9sgbru5iDbDZUnvKpfDSDqt/N7zA/jNiJgOBnHfzTTS1xWipF+huhT9ZEPZZQC2bwA+CvyhpFHgFWBZDxOjETEtTe6Wmpmgr4BYJjoPaSq7oWH/eqp5gIgYRkN2eZOXO0REbwwewCrzdJKAGBF9SECMiKhkyBwRUSQgRkTw5o3ZQ2RaBkTvB6+9c8j+r2cv2u+l+n8pf+XHu2vXHf/hSC/d6d6Hk4+rXXfXv+76Ts83jM7L35m6PKD/8oftJrppGRAjYobIKnNEREW5QoyIYMY9lldHAmJE9KjWm2xmlATEiOhdrhAjIorxqe7AYCUgRkRvch9iRMSbhm2VOXmZI6J3A3hBrKSFku6XNCJps6TLS/m1krZIekTSWknzG45ZJWmrpCckndum3bMkPSzpMUlfl9T1AjABMSKm2ihwpe3jgNOBlSVHynrgRNsnAU8CqwDKd8uAE4AlwFdLKuQ3SJpFlZx+me0TgR9RJZrqKAExInom19s6sb3D9sNlfzcwAiywfa/tiTSRG4Cjyv4FwG2299h+BtgKnNbU7CHAHttPls/rgd/pdj4JiBHRG1M9uldnq0nS0cCpwENNX10C3FX2FwA/bvhuWylrtAuY05CB76PAwm6/XysgSrpZ0k5JjzWUHSxpvaSnyp8tn8KXtLzUeaoknY6IYVF/DvFQSRsbthXNTUmaR5Ws/orGjJ2SrqYaVq+ZKGrTkzc/VLmblgFflvR9YHdpo6O6V4i3UI3VG30WuM/2IuC+8vkXSDoY+CLwXqpL2i+2C5wRMfNMYsi8ayLvetlW/0I70hyqYLjG9h0N5cuB84Dfa0hQt41fvNo7Ctje3Dfb37P9ftunAQ8AT3U7n1oB0fYDwAtNxRdQTVpS/rywxaHnAuttv2D7J1Tj+ObAGhEz1WBWmQXcBIzYvq6hfAlwFXB+SWg34U5gmaS5ko4BFgHfb9HuYeXPuaWdG5rrNOtnDvFw2zugmhQFDmtRp85YPyJmqsHkZT4DuBg4S9Kmsi2lyth5ELC+lN0AYHsz8E3gceBuYKXtMQBJ6yQdWdr9jKQR4BHg/9r+224d2ds3Zncd679RsZpTWAGw3/yMqiOmuzoryHXYfpDWsWJdh2OuAa5pUb60Yf8zwGcm05d+rhCfk3QEQPlzZ4s6tcb6ALZXT8wvzD7wwD66FRH7zIBXmadaPwHxTt680XE58Dct6twDnCPpnWUx5ZxSFhFDYBD3IU4ndW+7uRX4HvAeSdskfQL4EvBBSU8BHyyfkbRY0o0Atl8A/hT4Qdn+pJRFxDAYzBzitFFrDtH2RW2+OrtF3Y3ApQ2fbwZu7ql3ETF9zbCrvzqm5dtuNAr7/2TmzDtMtVmv16/78sKDatede+DJPfSmRh8Onlu77n4vd68zYdbr+TtTl7reolxTAmJEREVD9oLYPMscEVHkCjEiepchc0QEWVSJiPgFCYgREUUCYkRE9fDxsK0yJyBGRG8yhxgR0SABMSKiSEDc+2bvgfn/MDbV3ZgxRt9W/5G1nYvr/yvfc8jeeRRu7vOzu1cq5j9Rf5Jqv1eH7L/OvWj2nsG0kyFzRMSEBMSICKpFlSFbZc6zzBHRu8EkmVoo6X5JI5I2S7q8lF8raYukRyStlTS/4ZhVkrZKekLSuW3aPVvSwyUfy4OS3t3tdBIQI6JnA3pj9ihwpe3jgNOBlZKOp8rSeaLtk4AngVUA5btlwAlUWTy/KqnVxPTXqNKXngJ8A/hv3TqSgBgRvRvAFaLtHbYfLvu7gRFgge17bU+8uXEDVU4mqFIg32Z7j+1ngK1Ued9b9e7tZf8dtMnn1ChziBHRm8mlBzhU0saGz6ubk9UDSDoaOBV4qOmrS4Dby/4CqgA5oV1640uBdZJeAV6kuvrsqGtAlHQzcB6w0/aJpexa4D8BrwH/APyB7Z+2OPZZYDcwBozaXtzt9yJiZhCTuu1mV7f//iXNA74FXGH7xYbyq6mG1WsafrpZq578EbDU9kOSPgNcR0N6k1bqDJlvoRqnN2o5tm/jA7ZPSTCMGD6DyronaQ5VMFxj+46G8uVUF2S/Z3uipa7pjSX9KnCy7YkrzduBf9utH10Dou0HgBeaytqN7SPirWQwq8wCbgJGbF/XUL4EuAo433Zjdp07gWWS5ko6BlgEfL+p2Z8A75D0r8rnD1LNTXY0iDnExrF9MwP3SjLwl63mDCJiBhvMjdlnABcDj0raVMo+B3wFmAusr2ImG2xfZnuzpG8Cj1MNpVfaHgOQtA641PZ2Sf8F+JakcaoAeUm3jvQVEFuM7ZudUTp2WDmpLeWKs1VbK4AVAG+bNY+DHny6n669pYwd867adQ+/bGftut9edE8v3enqwqda3jbW0ivrDqtdd/Yz/9xLd96SZr80gGf3BvS2G9sP0npecF2HY64BrmlRvrRhfy2wdjJ96fm2mzZj++bObS9/7iwda7U0PlF3te3FthfvP+uAXrsVEfvSkCWq7ykgdhjbN9Y5UNJBE/vAOcBjvXY0IqYfjdfbZoquAVHSrcD3gPdI2ibpE8D1wEFUw+BNkm4odY8sY3iAw4EHJf2QasLzu7bv3itnERFTYlCrzNNF1zlE2xe1KL6pTd3twNKy/zRwcl+9i4jpa4YNh+vIkyoR0bsExIiIST+pMiMkIEZEzzQ+XBExATEiepM5xIiIN2XIHBExIQExIqKSK8SIiAkJiBERDGXWvQTEiOhJ7kOMiGjU+kVXM1YCYkT0LFeIEREwlDdmJy9zRPRsEO9DlLRQ0v2SRiRtlnR5Kb9W0hZJj0haK2l+wzGrJG2V9ISklq9gl/R35fWEmyRtl/TtbueTgBgRPRvQC2JHgSttH0eVO3mlpONpk92zfLcMOIEqI+hXJc1ubtT2+0vGz1Oo3ul6R3OdZgmIEdEbUy2q1Nk6NWPvsP1w2d9NlR1vQYfsnhcAt9neY/sZYCsd0pOUN/efBeQKMSL2nkG/MVvS0cCpwENNX10C3FX2FwA/bvhuWylr58PAfbZf7Pb7WVSJiN7VD3aHStrY8Hl1c1piSfOoktVf0Ri8WmT3bJWhr1NPLgJurNPJOjlVbpa0U9JjDWV/LOmfGiYsl7Y5dkmZ9Nwq6bN1OhQRM8PEjdk1rxB3TWTVLFtzMJxDFQzX2L6jobxVds9twMKGw48Ctrfso3QI1XD6u3XOqc6Q+RaqictmX56YsLT9S/lTyyTnXwAfAo4HLiqToRExDGw0Xm/rRFUW+puAEdvXNZS3y+55J7BM0lxJxwCLqBLZtfIx4Du2X61zSl0DYkks/0KdxpqcBmy1/bTt14DbqCZDI2JYDCYv8xnAxcBZTaPOltk9bW8Gvgk8DtwNrLQ9BiBpnaQjG9peBtxa93T6mUP8lKTfBzZSLZn/pOn7VhOf7+3j9yJimhnEkyq2H6T1vOAvjTwbjrkGuKZF+dKmz2dOpi+9rjJ/DTgWOAXYAfx5izqTmviUtELSRkkbXxt/pcduRcQ+Y2Dc9bYZoqeAaPs522O2x4G/ovU9QLUnPkubqycmXPefdUAv3YqIfW0wQ+Zpo6eAKOmIho8fBh5rUe0HwCJJx0jan2osf2cvvxcR09Og70Ocal3nECXdCpxJdR/RNuCLwJmSTqGK/c8Cnyx1jwRutL3U9qikTwH3ALOBm8tkaEQMibdcGlLbF7UovqlN3e3A0obP6+gwMRoRM9gMGw7XkSdVIqIn1Y3ZwxURExAjonfJqRIRUckVYkQEZA4xIuJN3Z9TnmkSECOidxkyR0SQRPUREb8gV4gREcVwxcMExIjoncaHa8ycgBgRvTG5MTsiAkA4N2ZHRLxhyAJi8jJHRO8GkKhe0kJJ90sakbRZ0uWl/FpJWyQ9ImmtpPkNx6wq2TyfkHRum3Yl6RpJT5a2/2u300lAjIjeTMwh1tk6G6XKy3QccDqwsmToXA+caPsk4ElgFUD5bhlwAlVG0K+WLJ/NPk711v7fLG3f1q0jCYgR0TONj9faOrG9w/bDZX83MAIssH2v7dFSbQNVGhKosnfeZnuP7WeArbROY/KHwJ+UVCfY3tntfBIQI6JHNYfL1ZD50IkkcmVb0apFSUcDpwIPNX11CXBX2W+V0XNBi+aOBX63/N5dkhZ1O6MsqkREb8xkFlV22V7cqYKkecC3gCtsv9hQfjXVsHrNRFGb3jSbC7xqe7GkjwA3A+/v1Ic6OVVuBs4Ddto+sZTdDrynVJkP/NT2KS2OfRbYDYwBo93+gUTEDDOg+xAlzaEKhmts39FQvpwq/pxtvxF962b03FbaBFgL/M9u/agzZL6FauLyDbZ/1/YpJQh+C7ij1YHFB0rdBMOIISO71taxDUlUeZpGbF/XUL4EuAo43/bLDYfcCSyTNFfSMcAi4Pstmv42cFbZ/22qhZmO6iSZeqCM69udyH9u+NGIeCsZzH2IZwAXA49K2lTKPgd8hWrYu74KNWywfZntzZK+CTxONZReaXsMQNI64NKS8O5LwBpJfwS8BFzarSP9ziG+H3jO9lNtvjdwryQDf2l7dZ+/FxHThQ1j/Y+ZbT9I63nBthk7bV8DXNOivDHr50+B/ziZvvQbEC8Cbu3w/Rm2t0s6jCrKb7H9QKuKZdVpBcDbZs3rs1sRsU/kSZWKpP2AjwC3t6tTLlsn7v9ZS+t7hSbqrra92Pbi/Wcd0Gu3ImJfGsCTKtNJP/ch/gdgi+1trb6UdKCkgyb2gXOAx/r4vYiYTgyMu942Q3QNiJJuBb4HvEfSNkmfKF8to2m4LOnIMqkJcDjwoKQfUq0Afdf23YPrekRMLYPH620zRJ1V5ovalH+8Rdl2YGnZfxo4uc/+RcR0ZQayqDKd5EmViOjdDJofrCMBMSJ6l4AYEQFvvNxhiCQgRkRvDCTJVEREkSvEiAiAwTy6N50kIEZEbwyeQfcY1pGAGBG9m0FPodSRgBgRvcscYkQEVTDMKnNERJErxIgIAOOxsanuxEAlDWlE9GZAr/+StFDS/ZJGJG2WdHkpv1bSFkmPSForaX7DMaskbZX0hKRz27R7i6RnJG0q2y8lwmuWgBgRvRvM679GgSttHwecDqyUdDywHjjR9klUCaJWAZTvlgEnUCXA+6qk2W3a/sxEQjzbm9rUeUMCYkT0xIDHXWvr2I69w/bDZX83MAIssH2v7dFSbQNVulGAC4DbbO+x/QywlQ5v45+MBMSI6I0H/4LYkuHzVOChpq8uAe4q+wuAHzd8t62UtXJNGXJ/WdLcbr+fgBgRPfPYWK0NOFTSxoZtRXNbkuZR5Xm/wvaLDeVXUw2r10wUtepKi7JVwG8C/wY4mCrHc0fyNFw2l/QvwI+aig8Fdk1Bd/a2YT0vGN5zG4bz+nXbv9pPA5LupvpnUccu20s6tDUH+A5wT1Oy+uXAZcDZE8nqJa0CsP3fy+d7gD+2/b0O7Z8JfNr2eR3PaToGxFYkbbS9eKr7MWjDel4wvOc2rOc1VVRlof868ILtKxrKlwDXAb9t+18ayk8AvkE1b3gkcB+waCJZfUO9I2zvKO1/GXjV9mc79SX3IUbEVDsDuBh4VNLESvDngK8Ac6lyugNssH2Z7c2Svgk8TjWUXjkRDEuSu0tLfqc1kn6Vaoi9iepKs6NcIU6xYT0vGN5zG9bzipm1qLJ6qjuwlwzrecHwntuwntdb3oy5QoyI2Ntm0hViRMReNSMCoqQl5ZnFrZI6rhLNJJKelfRoec5y41T3px+Sbpa0U9JjDWUHS1ov6any5zunso+9aHNefyzpnxqekV06lX2MwZn2AbE8o/gXwIeA44GLyrOMw+ID5TnLmT5JfwvVc6WNPgvcZ3sR1a0RM/H/zG7hl88L4MsNz8iu28d9ir1k2gdEqnuNttp+2vZrwG1UzzLGNGL7AeCFpuILqO4vo/x54T7t1AC0Oa8YUjMhIE7mucWZxsC9kv6+1aNMQ+Bw2zugeoAfOGyK+zNInyrPyN48E6cCorWZEBDrPrc4E51h+7eopgNWSvr3U92hqOVrwLHAKcAO4M+ntjsxKDMhIG4DFjZ8PgrYPkV9GahyNz22dwJrGdArjKaR5yQdAdVjVMDOKe7PQNh+zvaYqxycf8Xw/Xt7y5oJAfEHwCJJx0jan+rFkHdOcZ/6JulASQdN7APnAI91PmrGuRNYXvaXA38zhX0ZmIkgX3yY4fv39pY17Z9ltj0q6VPAPcBs4Gbbm6e4W4NwOLC2PKO5H/AN23dPbZd6J+lW4Eyq1zxtA74IfAn4pqRPAP8IfGzqetibNud1ZnkdvYFngU9OWQdjoPKkSkREMROGzBER+0QCYkREkYAYEVEkIEZEFAmIERFFAmJERJGAGBFRJCBGRBT/H7P601vknuRrAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 2 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 4.6: Polynomial approximation and visualization of the optical path length map of the example 4.3 using pylab.\n",
     "\n",
@@ -1158,22 +837,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXYAAAD8CAYAAABjAo9vAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAADnJJREFUeJzt3W+IpeV9xvHr2pmVhGgRnAEbZ3Va+qbrKl32VFp8kVRtWZPF0NCGGiMBXwyYPygY0tiFluRNXgRSS5M2GfKnoQ4VIYrFRsxKlZAX2pzV9c9mjYjEZjYpHhNKElpqV399ccY62Z3ZOec893nuPb/n+4Fh9vzZ+7p/s3DNs88854wjQgCAPHbV3gAAoCyKHQCSodgBIBmKHQCSodgBIBmKHQCSodgBIBmKHQCSodgBIJn5GqELCwuxvLxcIxoAZtbRo0dfjYjFnZ5XpdiXl5fV7/drRAPAzLL98ijP41QMACRDsQNAMhQ7ACRDsQNAMhQ7ACRDsQNAMhQ7ACRDsQNAMhQ7ACRDsQNAMhQ7ACRDsQNAMhQ7ACRDsQNAMhQ7ACRDsQNAMhQ7ACRTrNhtz9l+yvaDpdYEAIyv5BH7bZJOFFwPADCBIsVue0nSeyV9pcR6AIDJlTpiv0vSJyW9UWg9AMCEGhe77UOSXomIozs8b8V233Z/MBg0jQUAbKPEEfvVkm6w/UNJ90i6xvbdpz8pIlYjohcRvcXFxQKxAICtNC72iLgzIpYiYlnSn0n614j4UOOdAQAmwnXsAJDMfMnFIuIxSY+VXBMAMB6O2AEgGYodAJKh2AEgGYodAJKh2AEgGYodAJKh2AEgGYodAJKh2AEgGYodAJKh2AEgGYodAJKh2AEgGYodAJKh2AEgGYodAJKh2AEgGYodAJKh2AEgGYodAJKh2AEgmcbFbvtttv/N9tO2j9v+dImNAQAmM19gjf+RdE1E/NL2bknftf1QRDxeYG0AwJgaF3tEhKRfbtzcvfERTdcFAEymyDl223O2j0l6RdKRiHiixLoAgPEVKfaIeD0ifkfSkqSrbO87/Tm2V2z3bfcHg0GJWADAFopeFRMR/ynpMUkHt3hsNSJ6EdFbXFwsGQsA2KTEVTGLti/c+PPbJV0n6fmm6wIAJlPiqphfl/QN23MafqO4NyIeLLDur7j8A9L3X3rr9t7flI7fWzrl3MruWm7NbGZm5kzZjY/YI+KZiNgfEVdGxL6I+EyJjW12+hdEGt6+/AOlk86d7K7l1sxm5vZya2Z3aWYPr1ZsV6/Xi36/P/Lz3dv+sRh9mYnUyu5abs1sZm4vt2Z2hpltH42Is6w2xFsKAEAyFDsAJEOxA0AyM1Hst/7JePdnyO5abs1sZm4vt2Z2p2aOiNY/Dhw4EOO69bMRc78boQPDz7d+duwlJlYru2u5NbOZmZlnIVtSP0bo2Jm4KgYAwFUxANBZFDsAJEOxA0AyFDsAJEOxA0AyFDsAJEOxA0AyFDsAJEOxA0AyFDsAJEOxA0AyFDsAJEOxA0AyFDsAJEOxA0AyjYvd9h7bj9o+Yfu47dtKbAwAMJn5AmucknRHRDxp+wJJR20fiYjvF1gbADCmxkfsEfGTiHhy48+/kHRC0iVN1wUATKboOXbby5L2S3pii8dWbPdt9weDQclYAMAmxYrd9vmSvinp9oj4+emPR8RqRPQiore4uFgqFgBwmiLFbnu3hqW+FhH3lVgTADCZElfFWNJXJZ2IiM833xIAoIkSR+xXS7pZ0jW2j218vKfAugCACTS+3DEivivJBfYCACiAV54CQDIUOwAkMzPFvqZntay7tEuf1rLu0pqeTZ/dtdya2czMzJmyHRFTW3w7vV4v+v3+yM9f07O6Wfdp804t6R/1ft2kK4rv71zI7lpuzWxmbi+3ZnaGmW0fjYjejs+bhWKf12f0us7c55ysU/rLkls7Z7K7llszm5nby62ZnWHmUYt9Jk7FbPUFOdv9GbK7llszm5nby62Z3aWZZ6LYAQCjo9gBIJmZKPZ36vyx7s+Q3bXcmtnM3F5uzewuzTwTxX5Sd5zxBXinztdJ3ZE2u2u5NbOZub3cmtldmnkmrooBACS7KgYAMDqKHQCSodgBIBmKHQCSodgBIBmKHQCSodgBIBmKHQCSodgBIBmKHQCSKVLstr9m+xXbz5VYDwAwuVJH7P8g6WChtQAADRQp9oj4jqSflVgLANAM59gBIJnWit32iu2+7f5gMGgrFgA6p7Vij4jViOhFRG9xcbGtWADoHE7FAEAy8yUWsf1Pkt4tacH2uqS/ioivllj7TY/qIzquVYVelzWny7WiP9DflYw457K7llszm5mZOVN2kWKPiBtLrLOdR/URPae/fytPr///7Wn/o9TK7lpuzWxmZuZsM8/E7zz9W+2StNU+rY/rjWL7Opeyu5ZbM5uZ28utmZ1h5mS/83S7bz5tfFOqld213JrZzNxebs3s7sw8I8UOABgVxQ4AyVDsAJDMTBT7Pt061v0ZsruWWzObmdvLrZndpZmLXO44bW9eDlTj+tNa2V3LrZnNzMw8bW1nz8TljgCAdJc7AgBGRbEDQDIUOwAkQ7EDQDIUOwAkQ7EDQDIUOwAkQ7EDQDIUOwAkMzvFvr4mHVmW/nnX8PP6Wv7sruXWzGZmZk6UPRPvFaP1NempW6R4bXj7v18e3pakpZtyZnctt2Y2MzNzspln471iHlqQ/venZ96/+yLp+lfLbexcyu5abs1sZm4vt2Z2gplzvVfMVl+Qs92fIbtruTWzmbm93JrZHZp5NoodADCyIsVu+6DtH9h+0fanSqwJAJhM42K3PSfpi5Kul7RX0o229zZdFwAwmRJH7FdJejEiXoqI1yTdI+l9BdYFAEygRLFfIulHm26vb9z3K2yv2O7b7g8Gg/ESdl803v0l1cruWm7NbGZuL7dmdodmLlHs3uK+M66hjIjViOhFRG9xcXG8hCv+RvLu01J3D++ftlrZXcutmc3M7eXWzO7QzCWKfV3Snk23lyT9uMC6m1a8Sdr/dentl0ny8PP+r0//RQU1s7uWWzObmZl52lrObvwCJdvzkl6QdK2kk5K+J+mDEXF8u7/DL7MGgPGN+gKlxm8pEBGnbH9M0sOS5iR97WylDgCYriLvFRMR35L0rRJrAQCa4ZWnAJAMxQ4AycxOsa+tScvL0q5dw89rLb6Pcq3sruXWzGZmZs6UHRGtfxw4cCDGcvfdEeedFyG99XHeecP7p61Wdtdya2YzMzNPW6FsSf0YoWNn4/3YFxakn27x9pYXXSS9OuX3Ua6V3bXcmtnM3F5uzewEM496ueNsFLu3enHrhmnvv1Z213JrZjNze7k1sxPMnOsXbQAARkaxA0AyFDsAJEOxA0Ays1Hs73jHePdnyO5abs1sZm4vt2Z2h2aejWL/8peHF/VvtmvX8P6s2V3LrZnNzO3l1szu0syjXOxe+mPsFyhFDC/kv+yyCHv4uY0XFdTO7lpuzWxmZuYZyFaqFygBALiOHQC6imIHgGQodgBIhmIHgGQodgBIhmIHgGQodgBIplGx2/5T28dtv2F7x2srAQDT1/SI/TlJ75f0nQJ7AQAUMN/kL0fECUny2X47CACgVZxjB4Bkdjxit/2IpIu3eOhwRDwwapDtFUkrknTppZeOvEEAwHh2LPaIuK5EUESsSlqVhm8CVmJNAMCZOBUDAMk0vdzxj22vS/p9Sf9i++Ey2wIATKrpVTH3S7q/0F4AAAVwKgYAkqHYASAZih0AkqHYASAZih0AkqHYASAZih0AkqHYASAZih0AkqHYASAZih0AkqHYASAZih0AkqHYASAZih0AkqHYASAZih0AkqHYASAZih0AkqHYASAZih0AkqHYASCZRsVu+3O2n7f9jO37bV9YamMAgMk0PWI/ImlfRFwp6QVJdzbfEgCgiUbFHhHfjohTGzcfl7TUfEsAgCZKnmO/RdJD2z1oe8V233Z/MBgUjAUAbDa/0xNsPyLp4i0eOhwRD2w857CkU5LWtlsnIlYlrUpSr9eLiXYLANjRjsUeEded7XHbH5Z0SNK1EUFhA0BlOxb72dg+KOnPJb0rIv6rzJYAAE00Pcf+BUkXSDpi+5jtLxXYEwCggUZH7BHxW6U2AgAog1eeAkAyFDsAJEOxA0AyFDsAJEOxA0AyFDsAJEOxA0AyrvEuALYHkl5uPbi5BUmv1t5Ei7o2r8TMXTGrM18WEYs7PalKsc8q2/2I6NXeR1u6Nq/EzF2RfWZOxQBAMhQ7ACRDsY9ntfYGWta1eSVm7orUM3OOHQCS4YgdAJKh2Cdg+xO2w/ZC7b1Mm+3P2X7e9jO277d9Ye09TYvtg7Z/YPtF25+qvZ9ps73H9qO2T9g+bvu22ntqg+0520/ZfrD2XqaFYh+T7T2S/lDSv9feS0uOSNoXEVdKekHSnZX3MxW25yR9UdL1kvZKutH23rq7mrpTku6IiN+W9HuSPtqBmSXpNkknam9imij28f21pE9K6sQPJyLi2xFxauPm45KWau5niq6S9GJEvBQRr0m6R9L7Ku9pqiLiJxHx5Maff6Fh2V1Sd1fTZXtJ0nslfaX2XqaJYh+D7RsknYyIp2vvpZJbJD1UexNTcomkH226va7kJbeZ7WVJ+yU9UXcnU3eXhgdmb9TeyDQ1+tV4Gdl+RNLFWzx0WNJfSPqjdnc0fWebOSIe2HjOYQ3/677W5t5a5C3u68T/ymyfL+mbkm6PiJ/X3s+02D4k6ZWIOGr73bX3M00U+2ki4rqt7rd9haTfkPS0bWl4SuJJ21dFxH+0uMXitpv5TbY/LOmQpGsj7/Wx65L2bLq9JOnHlfbSGtu7NSz1tYi4r/Z+puxqSTfYfo+kt0n6Ndt3R8SHKu+rOK5jn5DtH0rqRcQsvpHQyGwflPR5Se+KiEHt/UyL7XkNfzh8raSTkr4n6YMRcbzqxqbIwyOUb0j6WUTcXns/bdo4Yv9ERByqvZdp4Bw7dvIFSRdIOmL7mO0v1d7QNGz8gPhjkh7W8IeI92Yu9Q1XS7pZ0jUb/7bHNo5mMeM4YgeAZDhiB4BkKHYASIZiB4BkKHYASIZiB4BkKHYASIZiB4BkKHYASOb/AN1oxgt0m1+JAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 4.7: spot diagram for the CCD of the example 4.4\n",
     "\n",
@@ -1225,29 +891,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "09b93ab47ab94752849b08ff73dfaa9b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-200.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 4.8: Chief ray for the system from the example 4.3 with an aperture stop between the two lenses\n",
     "\n",
-    "L1=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"BK7\"])\n",
-    "L2=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"BK7\"])\n",
+    "L1=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"N-BK7\"])\n",
+    "L2=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"N-BK7\"])\n",
     "\n",
     "C=CCD()\n",
     "\n",
@@ -1311,34 +962,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "00db135be73649c5b9f1ae26b95fbdb7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-120.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "155.0"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 4.9: Optical path of a ray\n",
     "\n",
@@ -1392,43 +1018,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Populating the interactive namespace from numpy and matplotlib\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "60336dd5b4cc47fc8f75e5491cbab481",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-225.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAD8CAYAAAB0IB+mAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAD3hJREFUeJzt3XuM5Wddx/H3Z7tNyyi32C3VbmeHiBBKazU5Fhs0XFquLdSW1ICjQkgcjSVQY1XKSEIT9g/BcAskMMGYGicBDG5K3dTaJU2IRsAptHbXBazY3S4VmcYGLUNLL1//OLPt7nZ2pjO/PfOb2ef9Sk7O+T2/y/PdX7OfPvv8njOTqkKSdPLb0ncBkqT1YeBLUiMMfElqhIEvSY0w8CWpEQa+JDXCwJekRhj4ktQIA1+SGrG17wKOdMYZZ9TExETfZUjSpnL77bffX1XbVjpuQwX+xMQEc3NzfZchSZtKkgNP5zindCSpEQa+JDXCwJekRhj4ktSIkQV+kl9I8pUkdySZS3LhqPqSJK1slKt0PghcX1U3J3nD4vYrRtifNBJzs/ewe/pOHji4wHPHx7h05wUMJif6LktatVEGfgHPWvz8bOC+EfYljcTc7D18buprPLLwGAAPHFjgc1NfAzD0temMcg7/GuBDSe4F/hy4bqmDkkwtTvnMzc/Pj7AcafV2T9/5RNgf9sjCY+yevrOniqS16zTCT7IHOGuJXdPAxcAfVNUXkvw68BfAJcceWFUzwAzAYDDwF+xqQ3ng4MKq2qWNrFPgV9VTAvywJH8FvHtx82+Az3TpS+rDc8fHeODAU8P9ueNjPVQjdTPKKZ37gJcvfn4V8O8j7EsaiUt3XsCpY6cc1Xbq2ClcuvOCniqS1m6UD21/B/hYkq3AQ8DUCPuSRuLwg1lX6ehkkKqNM20+GAzKH54mSauT5PaqGqx0nN+0laRGGPiS1AgDX5IaYeBLUiMMfElqhIEvSY0w8CWpEQa+JDXCwJekRhj4ktQIA1+SGmHgS1IjDHxJaoSBL0mNMPAlqREGviQ1wsCXpEYY+JLUCANfkhph4EtSIwx8SWqEgS9JjTDwJakRIwv8JBck+eckdyW5KcmzRtWXJGlloxzhfwZ4T1WdD+wC/miEfUmSVjDKwH8R8OXFz7cCbx5hX9LIzN4ME5fBll8avs/e3HdF0tqMMvD3Am9a/HwVcM4I+5JGYvZmmNoJB74HVcP3qZ2GvjanToGfZE+SvUu8LgfeAVyd5HbgmcCPj3ONqSRzSebm5+e7lCOdcNOfhIWHjm5beGjYLm02W7ucXFWXrHDIawCSvBC49DjXmAFmAAaDQXWpRzrRDv736tqljWyUq3TOXHzfAvwp8KlR9SWNyvjzVtcubWSjnMN/a5JvA98E7gP+coR9SSOx82oYO/3otrHTh+3SZtNpSmc5VfUx4GOjur60HiZfP3yf/uRwGmf8ecOwP9wubSYjC3zpZDH5egNeJwd/tIIkNcLAl6RGGPiS1AgDX5IaYeBLUiMMfElqhIEvSY0w8CWpEQa+JDXCwJekRhj4ktQIA1+SGmHgS1IjDHxJaoSBL0mNMPAlqREGviQ1wsCXpEYY+JLUCANfkhph4EtSIwx8SWpEp8BPclWSfUkeTzI4Zt91Se5O8q0kr+1WpiSpq60dz98LXAl8+sjGJOcCbwFeAvwMsCfJC6vqsY79SZLWqNMIv6r2V9W3lth1OfDZqnq4qv4TuBu4sEtfkqRuRjWHfzZw7xHbhxbbpE1nlruY4KNs4Xom+Ciz3NV3SdKarDilk2QPcNYSu6ar6sbjnbZEWx3n+lPAFMD4+PhK5Ujrapa7mOImFngEgAP8gCluAmCS8/ssTVq1FQO/qi5Zw3UPAeccsb0duO84158BZgAGg8GS/1OQ+jLNl54I+8MWeIRpvmTga9MZ1ZTOF4G3JDktyfOBnwO+NqK+pJE5yA9W1S5tZF2XZV6R5BBwEbA7yS0AVbUP+Dzwb8DfA1e7Qkeb0TjPXlW7tJF1XaWzq6q2V9VpVfW8qnrtEft2VtXPVtWLqurm7qVK628nFzPGqUe1jXEqO7m4p4qktfObttIyJjmfGd7IDp5NgB08mxne6Py9NqWuX7ySTnqTnG/A66TgCF+SGmHgS1IjDHxJaoSBL0mNMPAlqREGviQ1wsCXpEYY+JLUCANfkhph4EtSIwx8SWqEgS+t4DZmeTsTXMoW3s4EtzHbd0nSmvjD06Rl3MYsH2eKh1kA4Psc4OPD38jJK5nsszRp1RzhS8u4geknwv6wh1ngBqZ7qkhaOwNfWsY8B1fVLm1kBr60jG2Mr6pd2sgMfGkZb2MnpzF2VNtpjPE2dvZUkbR2Br60jFcyybuY4Ux2EMKZ7OBdzPjAVpuSq3SkFbySSQNeJwVH+JLUCANfkhph4EtSIzoFfpKrkuxL8niSwRHtP5XktiQPJvlE9zIlSV11HeHvBa4EvnxM+0PA+4BrO15fknSCdFqlU1X7AZIc2/5D4B+TvKDL9SVJJ07vc/hJppLMJZmbn5/vuxxJOmmtOMJPsgc4a4ld01V1Y9cCqmoGmAEYDAbV9XqSpKWtGPhVdcl6FCJJGq3ep3QkSeuj67LMK5IcAi4Cdie55Yh99wAfBt6e5FCScztVKknqpOsqnV3AruPsm+hybUnSieWUjiQ1wsCXpEYY+JLUCANfkhph4EtSIwx8SWqEgS9JjTDwJakRBr4kNcLAl6RGGPiS1AgDX5IaYeBLUiMMfElqhIEvSY0w8CWpEQa+JDXCwJekRhj4ktQIA1+SGmHgS1IjDHxJaoSBL0mN6BT4Sa5Ksi/J40kGR7S/OsntSe5afH9V91IlSV1s7Xj+XuBK4NPHtN8PvLGq7ktyHnALcHbHviRJHXQK/KraD5Dk2PZvHLG5Dzg9yWlV9XCX/iRJa7cec/hvBr5h2EtSv1YM/CR7kuxd4nX50zj3JcCfAb+7zDFTSeaSzM3Pz6+uemk9HJqFWyfgi1uG74dm+65IWpMVp3Sq6pK1XDjJdmAX8NtV9R/LXH8GmAEYDAa1lr6kkTk0C3dOwWMLw+0fHRhuA2yf7K8uaQ1GMqWT5DnAbuC6qvqnUfQhrYv900+G/WGPLQzbpU2m67LMK5IcAi4Cdie5ZXHXO4EXAO9Lcsfi68yOtUrr70cHV9cubWBdV+nsYjhtc2z7B4APdLm2tCE8Y3w4jbNUu7TJ+E1baTkv3gmnjB3ddsrYsF3aZAx8aTnbJ+GCGXjGDiDD9wtmfGCrTanrN22lk9/2SQNeJwVH+JLUCANfkhph4EtSIwx8SWqEgS9JjTDwJakRBr4kNcLAl6RGGPiS1AgDX5IaYeBLUiMMfElqhIEvSY0w8CWpEQa+JDXCwJekRhj4ktQIA1+SGmHgS1IjDHxJakSnwE9yVZJ9SR5PMjii/cIkdyy+7kxyRfdSJUldbO14/l7gSuDTS7QPqurRJD8N3Jnkpqp6tGN/kqQ16hT4VbUfIMmx7QtHbJ4OVJd+JEndjWwOP8lLk+wD7gJ+z9G9JPVrxRF+kj3AWUvsmq6qG493XlV9FXhJkhcDNyS5uaoeWuL6U8AUwPj4+NMuXJK0OiuO8Kvqkqo6b4nXccP+mPP3Az8EzjvO/pmqGlTVYNu2baurXloPs7MwMQFbtgzfZ2f7rkhak64PbZeU5PnAvYsPbXcALwLuGUVf0kjNzsLUFCwsPpY6cGC4DTA52V9d0hp0XZZ5RZJDwEXA7iS3LO76FYYrc+4AdgG/X1X3dytV6sH09JNhf9jCwrBd2mRStXEW0AwGg5qbm+u7DOlJW7bAUn9HEnj88fWvR1pCkturarDScX7TVlrO8RYSuMBAm5CBLy1n504YGzu6bWxs2C5tMga+tJzJSZiZgR07htM4O3YMt31gq01oJKt0pJPK5KQBr5OCI3xJaoSBL0mNMPAlqREGviQ1wsCXpEYY+JLUCANfkhph4EtSIwx8SWqEgS9JjTDwJakRBr4kNcLAl6RGGPiS1AgDX5IaYeBLUiMMfElqhIEvSY0w8CWpEQa+JDWiU+AnuSrJviSPJxkssX88yYNJru3SjySpu64j/L3AlcCXj7P/I8DNHfuQJJ0AW7ucXFX7AZI8ZV+SXwO+A/ywSx+SpBNjJHP4SX4C+BPg+qdx7FSSuSRz8/PzoyhHksTTCPwke5LsXeJ1+TKnXQ98pKoeXOn6VTVTVYOqGmzbtm01tUuSVmHFwK+qS6rqvCVeNy5z2kuBDya5B7gGeG+Sd56gmqX1NTsLExOwZcvwfXa274qkNek0h388VfWrhz8neT/wYFV9YhR9SSM1OwtTU7CwMNw+cGC4DTA52V9d0hp0XZZ5RZJDwEXA7iS3nJiypA1ievrJsD9sYWHYLm0yXVfp7AJ2rXDM+7v0IfXq4MHVtUsbmN+0lZYzPr66dmkDM/Cl5ezcCWNjR7eNjQ3bpU3GwJeWMzkJMzOwYwckw/eZGR/YalMaySod6aQyOWnA66TgCF+SGmHgS1IjDHxJaoSBL0mNMPAlqRGpqr5reEKSeeBA33Us4Qzg/r6L6Jn3wHvQ+p8fNu492FFVK/644Q0V+BtVkrmqesqvcGyJ98B70PqfHzb/PXBKR5IaYeBLUiMM/Kdnpu8CNgDvgfeg9T8/bPJ74By+JDXCEb4kNcLAX6Uk1yapJGf0Xct6S/KhJN9M8q9JdiV5Tt81rYckr0vyrSR3J3lP3/WstyTnJLktyf4k+5K8u++a+pDklCTfSPJ3fdeyVgb+KiQ5B3g10OqvO7oVOK+qfh74NnBdz/WMXJJTgE8CrwfOBd6a5Nx+q1p3jwJ/WFUvBn4ZuLrBewDwbmB/30V0YeCvzkeAPwaafPBRVf9QVY8ubn4F2N5nPevkQuDuqvpOVf0Y+Cxwec81rauq+q+q+vri5/9jGHpn91vV+kqyHbgU+EzftXRh4D9NSd4EfLeq7uy7lg3iHcDNfRexDs4G7j1i+xCNhd2RkkwAvwh8td9K1t1HGQ72Hu+7kC78BShHSLIHOGuJXdPAe4HXrG9F62+5e1BVNy4eM83wn/mz61lbT7JEW5P/wkvyk8AXgGuq6n/7rme9JLkM+H5V3Z7kFX3X04WBf4SqumSp9iTnA88H7kwCw6mMrye5sKq+t44ljtzx7sFhSd4GXAZcXG2s6T0EnHPE9nbgvp5q6U2SUxmG/WxV/W3f9ayzlwFvSvIG4HTgWUn+uqp+s+e6Vs11+GuQ5B5gUFUb8YcojUyS1wEfBl5eVfN917Mekmxl+ID6YuC7wL8Av1FV+3otbB1lOMq5Afifqrqm73r6tDjCv7aqLuu7lrVwDl+r8QngmcCtSe5I8qm+Cxq1xYfU7wRuYfiw8vMthf2ilwG/Bbxq8b/7HYujXW0yjvAlqRGO8CWpEQa+JDXCwJekRhj4ktQIA1+SGmHgS1IjDHxJaoSBL0mN+H8vMsmfj2AX7wAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "d=0.005 #Distancee between adjacent sources on the grating in mm\n",
     "    \n",
@@ -1467,52 +1059,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Populating the interactive namespace from numpy and matplotlib\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/lib/python3/dist-packages/IPython/core/magics/pylab.py:161: UserWarning: pylab import has clobbered these variables: ['SA']\n",
-      "`%matplotlib` prevents importing * from pylab and numpy\n",
-      "  \"\\n`%matplotlib` prevents importing * from pylab and numpy\"\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f02bda813b5c4f54aee6cd48aa640843",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-100.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD8CAYAAACMwORRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAEAZJREFUeJzt3W2MXGd5xvH/hROD1FJevEtL/RIbYdRaiDZom6LygVBSyc4Hu7ShiuUWSAIWUkORQBWpUoUqKKqgHyhIAerSEEBuQkgrcJGR20JQqlLTbASEOJZhMU2zcoQXk+YLBSfp3Q87JpP1rufs7uzbk/9PGu05z3PrzO0zq8tnz5wzk6pCktSW56x0A5Kk4TPcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ26aKWeeGRkpLZu3bpSTy9Ja9L999//w6oaHVS3YuG+detWxsfHV+rpJWlNSvJwlzpPy0hSgwx3SWqQ4S5JDTLcJalBhrskNchwl845eBBGRiCZfoyMTI9Ja9CKXQoprSoHD8I118ATTzw9duYMXHvt9PK+fSvTl7RAHrlLADfe+MxgP+fs2ek5aY0x3CWAhy9wX8iF5qRVynCXANatW9ictEoZ7hLAU08tbE5apQx3CeCSSxY2J61ShrsEcMstcPHF54+vXz89J60xhrsE05c6fvKTsGHD02MbNsBtt3kZpNYkr3OXztm3zyBXMzxyl6QGGe6S1CDDXZIaZLhLUoMGhnuS25KcTvLggLrfSPJUkquG154kaSG6HLnfDuy8UEGSdcAHgCND6EmStEgDw72q7gV+NKDsncA/AKeH0ZQkaXEWfc49yUbgjcDHO9TuTzKeZHxqamqxTy1JmsMw3lD9a+C9VTXw05Wq6kBVjVXV2Ojo6BCeWpI0m2HcoToG3JkEYAS4MsmTVfX5IWxbkrQAiw73qtp2bjnJ7cAXDXZJWlkDwz3JHcDlwEiSSeB9wMUAVTXwPLskafkNDPeq2tt1Y1X11kV1I0kaCu9QlaQGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYNDPcktyU5neTBOeb3JXmg9/hakl8bfpuSpPnocuR+O7DzAvPfB15XVa8C3g8cGEJfkqRF6PIdqvcm2XqB+a/1rR4FNi2+LUnSYgz7nPt1wJfmmkyyP8l4kvGpqakhP7Uk6ZyhhXuS1zMd7u+dq6aqDlTVWFWNjY6ODuupJUkzDDwt00WSVwGfAHZV1ZlhbFOStHCLPnJPsgX4R+CPquo7i29JkrRYA4/ck9wBXA6MJJkE3gdcDFBVHwduAjYAH00C8GRVjS1Vw5KkwbpcLbN3wPzbgLcNrSNJ0qJ5h6okNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1aGC4J7ktyekkD84xnyQfSTKR5IEkrx5+m5Kk+ehy5H47sPMC87uA7b3HfuBji29LkrQYA8O9qu4FfnSBkj3Ap2vaUeCFSV46rAYlSfM3jHPuG4FH+tYne2OSpBUyjHDPLGM1a2GyP8l4kvGpqakhPLUkaTbDCPdJYHPf+ibg1GyFVXWgqsaqamx0dHQITy1Jms0wwv0Q8ObeVTOvAR6vqkeHsF1J0gJdNKggyR3A5cBIkkngfcDFAFX1ceAwcCUwAfwYuGapmpUkdTMw3Ktq74D5Av54aB1JkhbNO1QlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQZ3CPcnOJCeSTCS5YZb5LUnuSfKNJA8kuXL4rUqSuhoY7knWAbcCu4AdwN4kO2aU/TlwV1VdClwNfHTYjUqSuuty5H4ZMFFVJ6vqLHAnsGdGTQG/0Ft+AXBqeC1KkuZr4BdkAxuBR/rWJ4HfnFHzF8A/J3kn8HPAFUPpTpK0IF2O3DPLWM1Y3wvcXlWbgCuBzyQ5b9tJ9icZTzI+NTU1/24lSZ10CfdJYHPf+ibOP+1yHXAXQFX9B/A8YGTmhqrqQFWNVdXY6OjowjqWJA3UJdzvA7Yn2ZZkPdNvmB6aUfPfwBsAkvwq0+HuobkkrZCB4V5VTwLXA0eA40xfFXMsyc1JdvfK3gO8Pcm3gDuAt1bVzFM3kqRl0uUNVarqMHB4xthNfcsPAa8dbmuSpIXyDlVJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqUKdwT7IzyYkkE0lumKPmD5I8lORYkr8fbpuSpPkY+DV7SdYBtwK/A0wC9yU51PtqvXM124E/A15bVY8leclSNSxJGqzLkftlwERVnayqs8CdwJ4ZNW8Hbq2qxwCq6vRw25QkzUeXcN8IPNK3Ptkb6/cK4BVJ/j3J0SQ7h9WgJGn+Bp6WATLLWM2yne3A5cAm4N+SvLKq/ucZG0r2A/sBtmzZMu9mJUnddDlynwQ2961vAk7NUvOFqnqiqr4PnGA67J+hqg5U1VhVjY2Oji60Z0nSAF3C/T5ge5JtSdYDVwOHZtR8Hng9QJIRpk/TnBxmo5Kk7gaGe1U9CVwPHAGOA3dV1bEkNyfZ3Ss7ApxJ8hBwD/CnVXVmqZqWJF1YqmaePl8eY2NjNT4+viLPLUlrVZL7q2psUJ13qEpSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDOoV7kp1JTiSZSHLDBequSlJJBn5LiCRp6QwM9yTrgFuBXcAOYG+SHbPUPR/4E+Drw25SkjQ/XY7cLwMmqupkVZ0F7gT2zFL3fuCDwE+G2J8kaQG6hPtG4JG+9cne2M8kuRTYXFVfHGJvkqQF6hLumWWsfjaZPAf4EPCegRtK9icZTzI+NTXVvUtJ0rx0CfdJYHPf+ibgVN/684FXAl9N8l/Aa4BDs72pWlUHqmqsqsZGR0cX3rUk6YK6hPt9wPYk25KsB64GDp2brKrHq2qkqrZW1VbgKLC7qsaXpGNJ0kADw72qngSuB44Ax4G7qupYkpuT7F7qBiVJ83dRl6KqOgwcnjF20xy1ly++LUnSYniHqiQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDWoU7gn2ZnkRJKJJDfMMv/uJA8leSDJl5NcMvxWJUldDQz3JOuAW4FdwA5gb5IdM8q+AYxV1auAu4EPDrtRSVJ3XY7cLwMmqupkVZ0F7gT29BdU1T1V9ePe6lFg03DblCTNR5dw3wg80rc+2Ruby3XAlxbTlCRpcS7qUJNZxmrWwuQPgTHgdXPM7wf2A2zZsqVji5Kk+epy5D4JbO5b3wScmlmU5ArgRmB3Vf10tg1V1YGqGquqsdHR0YX0K0nqoEu43wdsT7ItyXrgauBQf0GSS4G/YTrYTw+/TUnSfAwM96p6ErgeOAIcB+6qqmNJbk6yu1f2V8DPA59L8s0kh+bYnCRpGXQ5505VHQYOzxi7qW/5iiH3JUlaBO9QlaQGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAZ1CvckO5OcSDKR5IZZ5p+b5LO9+a8n2TrsRqUld/AgjIxAMv0YGZkek9aggeGeZB1wK7AL2AHsTbJjRtl1wGNV9XLgQ8AHht2otKQOHoRrroEzZ54eO3MGrr3WgNea1OXI/TJgoqpOVtVZ4E5gz4yaPcCnest3A29IkuG1KS2xG2+EJ544f/zs2ek5aY3pEu4bgUf61id7Y7PWVNWTwOPAhmE0KC2Lhx9e2Jy0SnUJ99mOwGsBNSTZn2Q8yfjU1FSX/qTlsW7dwuakVapLuE8Cm/vWNwGn5qpJchHwAuBHMzdUVQeqaqyqxkZHRxfWsbQUnnpqYXPSKtUl3O8DtifZlmQ9cDVwaEbNIeAtveWrgK9U1XlH7tKqdcklC5uTVqmB4d47h349cAQ4DtxVVceS3Jxkd6/s74ANSSaAdwPnXS4prWq33AIXX3z++Pr103PSGnNRl6KqOgwcnjF2U9/yT4A3Dbc1aRnt2zf9813vevpyyA0b4MMffnpOWkM6hbv0rLBvn0GuZvjxA5LUIMNdkhpkuEtSgwx3SWqQ4S5JDcpK3WuUZApYbR/aMQL8cKWbWGHug2nuB/cBrM59cElVDbzFf8XCfTVKMl5VYyvdx0pyH0xzP7gPYG3vA0/LSFKDDHdJapDh/kwHVrqBVcB9MM394D6ANbwPPOcuSQ3yyF2SGvSsDvckb0pyLMn/JZnzHfEkO5OcSDKRpKmPM07y4iT/kuS7vZ8vmqPuqSTf7D1mfp7/mjTodU3y3CSf7c1/PcnW5e9y6XXYD29NMtX3+r9tJfpcKkluS3I6yYNzzCfJR3r754Ekr17uHhfiWR3uwIPA7wH3zlWQZB1wK7AL2AHsTbJjedpbFjcAX66q7cCXmfuz+P+3qn6999g9R82a0fF1vQ54rKpeDnwI+MDydrn05vH7/dm+1/8Ty9rk0rsd2HmB+V3A9t5jP/CxZehp0Z7V4V5Vx6vqxICyy4CJqjpZVWeBO4E9S9/dstkDfKq3/Cngd1ewl+XU5XXt3zd3A29IMtv3Ba9lrf9+D1RV9zLL14L22QN8uqYdBV6Y5KXL093CPavDvaONwCN965O9sVb8YlU9CtD7+ZI56p7X+3Lzo0la+A+gy+v6s5reN5I9DmxYlu6WT9ff79/vnZK4O8nmWeZbtiYzoPkv60jyr8AvzTJ1Y1V9ocsmZhlbU5cYXWgfzGMzW6rqVJKXAV9J8u2q+t5wOlwRXV7XNf/ad9Dl3/hPwB1V9dMk72D6r5nfXvLOVo81+XvQfLhX1RWL3MQk0H+ksgk4tchtLqsL7YMkP0jy0qp6tPen5uk5tnGq9/Nkkq8ClwJrOdy7vK7naiaTXAS8gAv/+b4WDdwPVXWmb/VvafC9hwHWZAZ4Wmaw+4DtSbYlWQ9cDTRxtUjPIeAtveW3AOf9NZPkRUme21seAV4LPLRsHS6NLq9r/765CvhKtXdjyMD9MOP88m7g+DL2txocAt7cu2rmNcDj505lrmpV9ax9AG9k+n/lnwI/AI70xn8ZONxXdyXwHaaPVG9c6b6HvA82MH2VzHd7P1/cGx8DPtFb/i3g28C3ej+vW+m+h/RvP+91BW4GdveWnwd8DpgA/hN42Ur3vEL74S+BY73X/x7gV1a65yH/++8AHgWe6OXBdcA7gHf05sP0FUXf6/3+j610z10e3qEqSQ3ytIwkNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQf8Pk1rMId0csI0AAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Autocollimator with a plane mirror\n",
     "\n",
@@ -1526,37 +1075,38 @@
     "C=CCD()\n",
     "\n",
     "#There is a measure problem, if the angle is too small the cavity gets resonant\n",
-    "S=System(complist=[(C,(20,0,20),(0,pi/2,0)),(BS,(0,0,20),(0,0,0)),(L,(0,0,150),(0,-pi,0)),(M1,(0,0,170),(0,0,0)),(M2,(0,0,570),(SA,0,0))],n=1.)\n",
+    "S=System(complist=[(C,(20,0,20),(0,pi/2,0)),\n",
+    "                   (BS,(0,0,20),(0,0,0)),\n",
+    "                   (L,(0,0,150),(0,-pi,0)),\n",
+    "                   (M1,(0,0,170),(0,0,0)),(M2,(0,0,570),(SA,0,0))],n=1.)\n",
     "R=point_source_c(span=(0.04,0.04), num_rays=(2,2), wavelength=.65)\n",
     "\n",
     "S.ray_add(R)\n",
-    "S.propagate()\n",
-    "\n",
-    "% pylab inline\n",
+    "S.propagate()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pylab inline\n",
     "display(Plot3D(S,center=(0,0,300), size=(600,100),scale=2,rot=[(0,0,-3*pi/8),(0,3*pi/8,0)]))\n",
     "spot_diagram_c(C)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "invalid syntax (<ipython-input-22-f973670c479a>, line 5)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-22-f973670c479a>\"\u001b[0;36m, line \u001b[0;32m5\u001b[0m\n\u001b[0;31m    print 'The measured angle is SA=', (d/(150*2))\u001b[0m\n\u001b[0m                                    ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Calculating the small angle SA from data\n",
     "\n",
     "d=C.get_optical_path_data()[1][0]-C.get_optical_path_data()[1][1]\n",
     "\n",
-    "print 'The measured angle is SA=', (d/(150*2))\n",
+    "print('The measured angle is SA='), (d/(150*2))\n",
     "\n"
    ]
   },
@@ -1571,47 +1121,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e6738603a5244691a5a898c7c23b6f09",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-280.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100.05893998465334\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/lib/python3/dist-packages/pyoptools/raytrace/calc/calc.py:67: RuntimeWarning: invalid value encountered in true_divide\n",
-      "  a=p2p1xv2/d1xd2\n",
-      "/usr/lib/python3/dist-packages/pyoptools/raytrace/calc/calc.py:68: RuntimeWarning: invalid value encountered in true_divide\n",
-      "  b=p2p1xv1/d1xd2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "## Air spaced triplet telescope objective - \n",
     "\n",
-    "L1=SphericalLens(radius=15,curvature_s1=1/50.098,curvature_s2=-1/983.420,thickness=4.500,material=material.schott[\"BK7\"])\n",
-    "L2=SphericalLens(radius=15,curvature_s1=1/56.671,curvature_s2=-1/171.150,thickness=4.500,material=material.schott[\"BK7\"])\n",
-    "L3=SphericalLens(radius=10,curvature_s1=-1/97.339,curvature_s2=1/81.454,thickness=3.500,material=material.schott[\"SF1\"])\n",
+    "L1=SphericalLens(radius=15,curvature_s1=1/50.098,curvature_s2=-1/983.420,thickness=4.500,material=material.schott[\"N-BK7\"])\n",
+    "L2=SphericalLens(radius=15,curvature_s1=1/56.671,curvature_s2=-1/171.150,thickness=4.500,material=material.schott[\"N-BK7\"])\n",
+    "L3=SphericalLens(radius=10,curvature_s1=-1/97.339,curvature_s2=1/81.454,thickness=3.500,material=material.schott[\"N-SF1\"])\n",
     "\n",
     "OA=Ray(pos=(0,0,-10000),dir=(0,0,1),wavelength=.55) # Optical axis\n",
     "\n",
@@ -1650,18 +1168,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Finding the plane of the circle of least confusion\n",
     "\n",
     "def CircleSph(lp):\n",
-    "    L=library.Edmund.get(\"45113\")\n",
+    "    L=library.Edmund.get(\"45129\")\n",
     "    CSph=CCD(size=(3,3))\n",
     "\n",
     "    SSph=System(complist=[(L1,(0,0,20),(0,0,0)),(CSph,(0,0,lp),(0,0,0))],n=1)\n",
-    "    PB= parallel_beam_c(size=(2,2),num_rays=(5,5), wavelength=.650)\n",
+    "    PB= parallel_beam_c(size=(1.5,1.5),num_rays=(5,5), wavelength=.650)\n",
     "\n",
     "    SSph.ray_add(PB)\n",
     "    SSph.propagate()\n",
@@ -1671,20 +1189,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.664624741817641"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Seed\n",
     "CircleSph(25)"
@@ -1692,30 +1199,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Optimization terminated successfully.\n",
-      "         Current function value: 0.000044\n",
-      "         Iterations: 25\n",
-      "         Function evaluations: 50\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "array([112.18917847])"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from scipy.optimize import fmin\n",
     "fmin(CircleSph,25)"
@@ -1723,34 +1209,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c7d43d26cc7149e5931e4981acbbd2b7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-160.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Spherical lens\n",
     "\n",
-    "PB= parallel_beam_c(size=(2,2),num_rays=(5,5), wavelength=.650)\n",
-    "L1=library.Edmund.get(\"45113\") #f=200 r= 25\n",
+    "PB= parallel_beam_c(size=(1.5,1.5),num_rays=(5,5), wavelength=.650)\n",
+    "L1=library.Edmund.get(\"45129\") #f=6 r= 1.5\n",
     "\n",
     "CSph=CCD(size=(3,3))\n",
     "\n",
     "\n",
-    "SSph=System(complist=[(L1,(0,0,20),(0,0,0)),(CSph,(0,0,24.91676331),(0,0,0))],n=1)\n",
+    "SSph=System(complist=[(L1,(0,0,20),(0,0,0)),(CSph,(0,0,26.11808777),(0,0,0))],n=1)\n",
     "\n",
     "SSph.ray_add(PB)\n",
     "SSph.propagate()\n",
@@ -1760,7 +1231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1797,7 +1268,7 @@
     "poly=A2*r2+A4*r4+ A6*r6 +A8*r8 +A10*r10\n",
     "\n",
     "asf1=Aspherical(Kx=k, Ky=k, Ax=1./R,Ay=1./R, shape=Circular(radius=2.5),\n",
-    "                                poly=poly, reflectivity=.5)\n",
+    "                                poly=poly)\n",
     "\n",
     "\n",
     "AS=Component(surflist=[(asf2, (0, 0, 0), (0, 0, 0)), (asf1, (0, 0, 2.8+.35), (0,0, 0))], material=1.58913)\n"
@@ -1805,14 +1276,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Finding the plane of the circle of least confusion\n",
     "\n",
     "def CircleAsph(lp):\n",
-    "    L=library.Edmund.get(\"45113\")\n",
     "    CAsph=CCD(size=(3,3))\n",
     "\n",
     "    SAsph=System(complist=[(AS,(0,0,20),(0,0,0)),(CAsph,(0,0,lp),(0,0,0))],n=1)\n",
@@ -1826,50 +1296,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.011224380388868025"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "CircleAsph(25)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Optimization terminated successfully.\n",
-      "         Current function value: 0.000543\n",
-      "         Iterations: 15\n",
-      "         Function evaluations: 30\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "array([24.95140076])"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from scipy.optimize import fmin\n",
     "fmin(CircleAsph,25)"
@@ -1877,24 +1315,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "503675ce710b42dfad5da1ba9bcb9611",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-160.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Visualization of the aspheric lens\n",
     "\n",
@@ -1912,55 +1335,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Populating the interactive namespace from numpy and matplotlib\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/lib/python3/dist-packages/IPython/core/magics/pylab.py:161: UserWarning: pylab import has clobbered these variables: ['f', 'fmin', 'poly']\n",
-      "`%matplotlib` prevents importing * from pylab and numpy\n",
-      "  \"\\n`%matplotlib` prevents importing * from pylab and numpy\"\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAD8CAYAAABzTgP2AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAE3dJREFUeJzt3W+IZXd9x/H3N1mSMC3GTbKJaTY7s5Kl7aZ9IF5ipX1g1Ww2gibFFFaGurTKIsUHUvpgw9RGoguJFBSrRQYtLGYwqRZxS2yXNYlQBWNmTaykuu4m3c1OE3TDhrTJoCH02wfnjJkzubPz55z759z7fsHlnPO7v3vne/9+5p7f+ROZiSRJSy4adAGSpOFiMEiSKgwGSVKFwSBJqjAYJEkVBoMkqcJgkCRVGAySpAqDQZJUsWXQBWzGVVddlVNTU4MuQ5Ja5fjx489n5ra1+rUyGKamppifnx90GZLUKhFxZj39XJUkSaowGCRJFQaDJKnCYJAkVRgMkqQKg6HN5uZgagouuqiYzs0NuiJp8Pxc1NbKzVVF8WY/cAAWF4vlM2eKZYDp6cHVJQ2Sn4tGRBtP7dnpdHLs92OYmire9CtNTsLp0/2uRhoOfi4uKCKOZ2ZnrX6uSmqrZ57ZWLs0DvxcNMJgaKsdOzbWLo0DPxeNMBja6tAhmJiotk1MFO3SuPJz0QiDoa2mp2F2tlh3GlFMZ2cdYNN483PRCAefJWlMOPgsSdqURoIhIvZGxImIOBURB7tcf2lEPFBe/2hETJXtN0fE8Yj4cTl9ZxP1SJI2r3YwRMTFwBeAW4HdwAciYveKbh8CXsjMG4DPAPeW7c8D783M3wf2A1+pW48kqZ4mfjHcBJzKzKcz8xXgfuC2FX1uAw6X818H3hURkZmPZ+azZfuTwGURcWkDNUmSNqmJYLgOOLtseaFs69onM18FXgSuXNHn/cDjmfmrBmqSJG1SE8dKii5tKzd1umCfiLiRYvXSnlX/SMQB4ADADndWkaSeaeIXwwJw/bLl7cCzq/WJiC3A5cD5cnk78A3gg5n51Gp/JDNnM7OTmZ1t29Y8l7UkaZOaCIbHgF0RsTMiLgH2AUdW9DlCMbgMcAfwcGZmRLwReBC4MzO/10AtkqSaagdDOWbwUeAo8BPgnzLzyYi4OyLeV3b7MnBlRJwC/gpY2qT1o8ANwMcj4onycnXdmiRJm+eez5I0JtzzWZK0KQaDJKnCYJCa4HmGNUI857NUl+cZ1ojxF4NU18zMa6GwZHGxaJdayGCQ6vI8wxoxBoNUl+cZ1ogxGKS6PM+wRozBINXleYY1YtwqSWrC9LRBoJHhLwZJUoXBIEmqMBgkSRUGgySpwmCQJFUYDJKkCoNBklRhMEiSKgwGNcdzEownX/eR457PaobnJBhPvu4jKTJz0DVsWKfTyfn5+UGXoeWmpoovhZUmJ+H06X5Xo37xdW+ViDiemZ21+rkqSc3wnATjydd9JBkMaobnJBhPvu4jyWBQMzwnwXjydR9JBoOaMe7nJBjXLXPG/XUfUQ4+S3Wt3DIHiv+a/YLUkHHwWeqXmZlqKECxPDMzmHqkmgwGqS63zNGIMRikutwyRyPGYJDqcsscjRiDQarLLXM0YjxWktSE6WmDQCPDXwySpAqDQZJUYTBIkioMBklSRSPBEBF7I+JERJyKiINdrr80Ih4or380IqbK9isj4pGIeCkiPt9ELZKkemoHQ0RcDHwBuBXYDXwgInav6PYh4IXMvAH4DHBv2f5L4OPAX9etQ5LUjCZ+MdwEnMrMpzPzFeB+4LYVfW4DDpfzXwfeFRGRmS9n5ncpAkKSNASaCIbrgLPLlhfKtq59MvNV4EXgyo38kYg4EBHzETF/7ty5GuVKki6kiWCILm0rj+W9nj4XlJmzmdnJzM62bds2clNJ0gY0EQwLwPXLlrcDz67WJyK2AJcD5xv425KkhjURDI8BuyJiZ0RcAuwDjqzocwTYX87fATycbTxDkCSNgdrHSsrMVyPio8BR4GLgHzPzyYi4G5jPzCPAl4GvRMQpil8K+5ZuHxGngTcAl0TE7cCezPzPunVJkjankYPoZea3gG+taPvbZfO/BP50ldtONVGDJKkZ7vksSaowGCRJFQaDJKnCYJAkVRgMkqQKg0GSVGEwSJIqDAZJUoXBIEmqMBgkSRUGgySpwmCQJFUYDJKkCoNBklRhMEiSKgwG6ULm5mBqCi66qJjOzQ3nfUoNauREPdJImpuDAwdgcbFYPnOmWAaYnh6e+5QaFm089XKn08n5+flBl6FRNzVVfHGvNDkJp08Pz31K6xQRxzOzs1Y/VyVJq3nmmY21D+o+pYYZDNJqduzYWPug7lNqmMEgrebQIZiYqLZNTBTtw3SfUsMMBmk109MwO1us/48oprOz9QaJe3GfUsMcfJakMeHgsyRpUwwGSVKFwSBJqjAYNH7ackiKttSpkeMhMTRe2nJIirbUqZHkVkkaL205JEVb6lSruFWS1E1bDknRljo1kgwGjZe2HJKiLXVqJBkMGi9tOSRFW+rUSDIYNF7ackiKttSpkeTgsySNCQefJUmb0kgwRMTeiDgREaci4mCX6y+NiAfK6x+NiKll191Ztp+IiFuaqEeStHm1gyEiLga+ANwK7AY+EBG7V3T7EPBCZt4AfAa4t7ztbmAfcCOwF/iH8v40CL3a03Yc9uAdh8cIvXmc4/LctUlm1roAbweOLlu+E7hzRZ+jwNvL+S3A80Cs7Lu834Uub33rW1MNu+++zImJTHjtMjFRtA/j/Q6TcXiMmb15nOPy3A0JYD7X8b3exKqk64Czy5YXyraufTLzVeBF4Mp13lb9MDPz2uEXliwuFu3DeL/DZBweI/TmcY7Lc9cyTQRDdGlbuanTan3Wc9viDiIORMR8RMyfO3dugyVqTb3a03Yc9uAdh8cIvXmc4/LctUwTwbAAXL9seTvw7Gp9ImILcDlwfp23BSAzZzOzk5mdbdu2NVC2Knq1p+047ME7Do8RevM4x+W5a5kmguExYFdE7IyISygGk4+s6HME2F/O3wE8XK7vOgLsK7da2gnsAn7QQE3aqF7taTsOe/COw2OE3jzOcXnu2mY9AxFrXYD3AD8DngJmyra7gfeV85cBXwNOUXzxv3nZbWfK250Abl3P33PwuUfuuy9zcjIzopg2NQDYq/sdJuPwGDN78zjH5bkbAqxz8Nk9nyVpTLjnsyRpUwwGSVKFwSBJqjAYNH7acgiGttSpkbNl0AVIfTU3BwcOvLa37ZkzxTIM17kO2lKnRpJbJWm8TE0VX7IrTU7C6dP9rmZ1balTreJWSVI3bTkEQ1vq1EgyGDRe2nIIhrbUqZFkMGi8tOUQDG2pUyPJYNB4mZ6G2dliXX1EMZ2dHb4B3bbUqZHk4LMkjQkHnyVJm2IwSJIqDAbpQnqx97F7NGvIueeztJpe7H3sHs1qAQefpdX0Yu9j92jWADn4LNXVi72P3aNZLWAwSKvpxd7H7tGsFjAYpNX0Yu9j92hWCxgM0mp6sfexezSrBRx8lqQx4eCzJGlTDAZJUoXBIEmqMBgkSRUGgySpwmCQJFUYDJKkCoNBklRhMEiSKgwGSVKFwSBJqjAYJEkVBoMkqcJgkCRVGAySpIpawRARV0TEsYg4WU63rtJvf9nnZETsX9Z+KCLORsRLdeqQJDWn7i+Gg8BDmbkLeKhcroiIK4C7gLcBNwF3LQuQfynbJElDom4w3AYcLucPA7d36XMLcCwzz2fmC8AxYC9AZn4/M5+rWYMkqUF1g+GapS/2cnp1lz7XAWeXLS+UbZKkIbRlrQ4R8W3gTV2umlnn34gubRs+0XREHAAOAOzYsWOjN5ckrdOawZCZ717tuoj4eURcm5nPRcS1wC+6dFsA3rFseTvwnQ3WSWbOArMAnU5nw8EiSVqfuquSjgBLWxntB77Zpc9RYE9EbC0HnfeUbZKkIVQ3GO4Bbo6Ik8DN5TIR0YmILwFk5nngk8Bj5eXuso2I+HRELAATEbEQEZ+oWY8kqabIbN9amU6nk/Pz84MuQ5JaJSKOZ2ZnrX7u+SxJqjAYJEkVBoMkqcJgkCRVGAySpAqDQWrC3BxMTcFFFxXTublBVyRt2pp7Pktaw9wcHDgAi4vF8pkzxTLA9PTg6pI2yV8MUl0zM6+FwpLFxaJdaiGDQarrmWc21i4NOYNBqmu1o/16FGC1lMGg5ozrAOyhQzAxUW2bmCjax8G4vu4jzMFnNWOcB2CXHt/MTLH6aMeOIhRG/XHDeL/uI8yD6KkZU1PFl8JKk5Nw+nS/q1G/+Lq3igfRU385ADuefN1HksGgZjgAO5583UeSwaBmjPsA7LjydR9JBoOaMT0Ns7PFuuWIYjo76wDkqPN1H0kOPkvSmHDwWZK0KQaDJKnCYJAkVRgMkqQKg0GSVGEwSJIqDAZJUoXBIEmqMBikJnhOAo0Qz8cg1eU5CTRi/MUg1TUz81ooLFlcLNqlFjIYpLo8J4FGjMEg1eU5CTRiDAapLs9JoBFjMEh1eU4CjRi3SpKaMD1tEGhk+ItBklRhMEiSKmoFQ0RcERHHIuJkOd26Sr/9ZZ+TEbG/bJuIiAcj4qcR8WRE3FOnFklSM+r+YjgIPJSZu4CHyuWKiLgCuAt4G3ATcNeyAPm7zPwd4C3AH0bErTXrkSTVVDcYbgMOl/OHgdu79LkFOJaZ5zPzBeAYsDczFzPzEYDMfAX4IbC9Zj2SpJrqBsM1mfkcQDm9ukuf64Czy5YXyrZfi4g3Au+l+NXRVUQciIj5iJg/d+5czbIlSatZc3PViPg28KYuV633QDDRpS2X3f8W4KvA5zLz6dXuJDNngVmATqeTq/WTJNWzZjBk5rtXuy4ifh4R12bmcxFxLfCLLt0WgHcsW94OfGfZ8ixwMjM/u66KJUk9VXdV0hFgfzm/H/hmlz5HgT0RsbUcdN5TthERnwIuBz5Wsw5JUkPqBsM9wM0RcRK4uVwmIjoR8SWAzDwPfBJ4rLzcnZnnI2I7xeqo3cAPI+KJiPhwzXokSTVFZvtW13c6nZyfnx90GZLUKhFxPDM7a/Vzz2dJUoXB0GaeZ1h6PT8XtXl01bbyPMPS6/m5aIRjDG01NVW86VeanITTp/tdjTQc/FxckGMMo87zDEuv5+eiEQZDW3meYen1/Fw0wmBoK88zLL2en4tGGAxt5XmGpdfzc9EIB58laUw4+CxJ2hSDQZJUYTBIkioMBklShcEgSapo5VZJEXEO6LLfe19dBTw/4Bo2qm01t61esOZ+aFu9MDw1T2bmtrU6tTIYhkFEzK9ns69h0raa21YvWHM/tK1eaF/NrkqSJFUYDJKkCoNh82YHXcAmtK3mttUL1twPbasXWlazYwySpAp/MUiSKgyGC4iIKyLiWEScLKdbV+m3v+xzMiL2L2v/t4j4UUQ8GRFfjIiLh7nmiJiIiAcj4qdlzfcMc71l+6GIOBsRL/Wh1r0RcSIiTkXEwS7XXxoRD5TXPxoRU8uuu7NsPxERt/S61jr1RsSVEfFIRLwUEZ/vR60N1HxzRByPiB+X03e2oOabIuKJ8vKjiPiTftW8psz0ssoF+DRwsJw/CNzbpc8VwNPldGs5v7W87g3lNIB/BvYNc83ABPDHZZ9LgH8Hbh3Wesvr/gC4Fnipx3VeDDwFvLl8bn4E7F7R5y+BL5bz+4AHyvndZf9LgZ3l/Vw8xPX+BvBHwEeAz/f6PdtQzW8Bfquc/z3gv1tQ8wSwpZy/FvjF0vKgL/5iuLDbgMPl/GHg9i59bgGOZeb5zHwBOAbsBcjM/yn7bKF40/RjQGfTNWfmYmY+ApCZrwA/BLYPa71lnd/PzOd6XCPATcCpzHy6fG7up6h9ueWP5evAuyIiyvb7M/NXmflfwKny/oay3sx8OTO/C/yyxzWuVKfmxzPz2bL9SeCyiLh0yGtezMxXy/bL6M/3w7oYDBd2zdKXTjm9ukuf64Czy5YXyjYAIuIoxX8C/0vxpui12jUDRMQbgfcCD/WoziWN1NsH66nh133KD/yLwJXrvG3T6tQ7KE3V/H7g8cz8VY/q7FpPaUM1R8TbIuJJ4MfAR5YFxUBtGXQBgxYR3wbe1OWqmfXeRZe2Xyd/Zt4SEZcBc8A7Kf7braXXNUfEFuCrwOcy8+mNV7jij/W43j5ZTw2r9RlE/XXqHZTaNUfEjcC9wJ4G67qQWjVn5qPAjRHxu8DhiPjXzOz3L7XXGftgyMx3r3ZdRPw8Iq7NzOciYmkd4EoLwDuWLW8HvrPib/wyIo5Q/KSsHQx9qHkWOJmZn61bK/TnOe6DBeD6FTU8u0qfhTJcLwfOr/O2TatT76DUqjkitgPfAD6YmU/1vtxKPUs29Txn5k8i4mWK8ZGBn57SVUkXdgRY2gJmP/DNLn2OAnsiYmu5Rc0e4GhE/Gb5Rbf0H/h7gJ8Oc81lrZ+ieON+rA+1Qs16++gxYFdE7IyISygGEY+s6LP8sdwBPJzFyOIRYF+5dcpOYBfwgyGud1A2XXO56vNB4M7M/F7fKq5X887yu4GImAR+Gzjdn7LXMOjR72G+UKwHfAg4WU6vKNs7wJeW9fsLigHFU8Cfl23XULxp/oNiMOzv6cMWBzVr3k7xE/cnwBPl5cPDWm/Z/mmK/8j+r5x+ooe1vgf4GcVWKDNl293A+8r5y4CvlTX+AHjzstvOlLc7QY+39Gqo3tMU/9W+VD6vu4e5ZuBvgJeXvW+fAK4e8pr/rPxueIJiQ4/b+1Hvei7u+SxJqnBVkiSpwmCQJFUYDJKkCoNBklRhMEiSKgwGSVKFwSBJqjAYJEkV/w+eaxecFQBrPwAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZkAAAD8CAYAAACl69mTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAHYRJREFUeJzt3X+MXeV95/H3Bzu4dTchNhhwbewxYtKurW1RmDWw3W5JE7BB2xq6RB1kFSslGpUNf61a1ZYlqIyQYFcrJHaBaBZoTDIbQ2kDowTiGNOU7DYBDywQTOp4ABtm7QWDqQnrLKzJd/84zyzHl/tr5p5z58ydz0u6uud8z3Oe8zxz7/XX95znPkcRgZmZWRlOmekGmJlZ73KSMTOz0jjJmJlZaZxkzMysNE4yZmZWGicZMzMrjZOMmZmVxknGzMxK4yRjZmalmT/TDZhpZ5xxRvT19c10M8zMZo1nnnnmrYhY0k7ZOZ9k+vr6GBsbm+lmmJnNGpIOtlvWp8vMzKw0hSQZSesl7ZM0Lmlzne0LJD2Qtj8lqS+3bUuK75O0Lhe/T9Kbkl6sqWuxpF2S9qfnRSkuSXekul6Q9Nki+mZmZtPXcZKRNA+4E7gcWA1cI2l1TbHrgHci4jzgduC2tO9qYBBYA6wH7kr1AXwtxWptBnZHRD+wO62Tjt+fHkPA3Z32zczMOlPEN5m1wHhEvBIRHwA7gA01ZTYA29PyQ8DnJSnFd0TE+xHxKjCe6iMingSO1jlevq7twJW5+P2R+RHwaUlLC+ifmZlNUxFJZhnwem59IsXqlomIE8Ax4PQ29611VkQcTnUdBs6cQjvMzKyLikgyqhOrvRNaozLt7FtkO7KC0pCkMUljR44cmebheszICPT1wSmnZM8jIzPdIrOZ589Fx4pIMhPAObn15cChRmUkzQdOIzsV1s6+td6YPA2Wnt+cQjsAiIjhiBiIiIElS9oa6t3bRkZgaAgOHoSI7HloyB8om9v8uShEEUlmD9AvaZWkU8ku5I/WlBkFNqXlq4EnIrvv8ygwmEafrSK7aP90i+Pl69oEPJKLX5tGmV0EHJs8rWYtbN0Kx4+fHDt+PIubzVX+XBSi4x9jRsQJSTcAO4F5wH0RsVfSNmAsIkaBe4GvSxon+wYzmPbdK+lB4CXgBPCViPgQQNI3gUuAMyRNADdFxL3ArcCDkq4DXgO+mJryKHAF2eCB48CXOu3bnPHaa1OLm80F/lwUQtkXirlrYGAg5vwv/vv6slMBtVauhAMHut0as2rw56IhSc9ExEA7Zf2Lf4NbboGFC0+OLVyYxc3mKn8uCuEkY7BxIwwPZ/9Dk7Ln4eEsbjZX+XNRCJ8u8+kyM7Mp8ekyMzOrBCcZMzMrjZOMmZmVxknGzMxK4yRjZmalcZIxM7PSOMmYVY1n/rUe0vHcZWZWoMmZfycnZpyc+Rf8I0CblfxNxqxKPPOv9RgnGbMq8cy/1mOcZMyqZMWKqcXNKs5JxqxKPPOv9RgnGbMq8cy/1mM8usysajZudFKxnlHINxlJ6yXtkzQuaXOd7QskPZC2PyWpL7dtS4rvk7SuVZ2SfiDpufQ4JOnhFL9E0rHcthuL6JuZmU1fx99kJM0D7gQuBSaAPZJGI+KlXLHrgHci4jxJg8BtwB9KWg0MAmuAXwUel/SZtE/dOiPit3PH/mvgkdxxfhAR/7rTPpmZWTGK+CazFhiPiFci4gNgB7ChpswGYHtafgj4vCSl+I6IeD8iXgXGU30t65T0SeB3gYcL6IOZmZWgiCSzDHg9tz6RYnXLRMQJ4BhwepN926nzKmB3RLybi10s6XlJj0la06jBkoYkjUkaO3LkSKv+mZnZNBWRZFQnVntP50ZlphrPuwb4Zm79WWBlRPwm8J9o8g0nIoYjYiAiBpYsWdKomJmZdaiIJDMBnJNbXw4calRG0nzgNOBok32b1inpdLJTat+ZjEXEuxHxXlp+FPiEpDM66ZiZmXWmiCSzB+iXtErSqWQX8kdryowCm9Ly1cATEREpPphGn60C+oGn26jzi8C3I+L/TAYknZ2u8yBpberb2wX0z8zMpqnj0WURcULSDcBOYB5wX0TslbQNGIuIUeBe4OuSxsm+wQymffdKehB4CTgBfCUiPgSoV2fusIPArTVNuRq4XtIJ4OfAYEpkZmY2QzTX/x0eGBiIsbGxmW6GmdmsIemZiBhop6ynlTEzs9I4yZiZWWmcZMzMrDROMlYdvre9TfJ7oWd4FmarBt/b3ib5vdBTPLrMo8uqoa8v+8ek1sqVcOBAt1tjM8nvhcrz6DKbfXxve5vk90JPcZKxavC97W2S3ws9xUnGqsH3trdJfi/0FCcZqwbf294m+b3QU3zh3xf+zcymxBf+zcysEpxkzMysNE4yZmZWGicZMzMrjZOMmZmVppAkI2m9pH2SxiVtrrN9gaQH0vanJPXltm1J8X2S1rWqU9LXJL0q6bn0OD/FJemOVP4FSZ8tom9mXefJIa2HdDxBpqR5wJ3ApcAEsEfSaES8lCt2HfBORJwnaRC4DfhDSavJbqW8BvhV4HFJn0n7NKvzzyLioZqmXA70p8eFwN3p2Wz28OSQ1mOK+CazFhiPiFci4gNgB7ChpswGYHtafgj4vCSl+I6IeD8iXgXGU33t1FlrA3B/ZH4EfFrS0gL6Z9Y9W7d+lGAmHT+exc1moSKSzDLg9dz6RIrVLRMRJ4BjwOlN9m1V5y3plNjtkhZMoR1m1ebJIa3HFJFkVCdWO41AozJTjQNsAX4d+OfAYuDPp9COrKA0JGlM0tiRI0fqFTGbGZ4c0npMEUlmAjgnt74cONSojKT5wGnA0Sb7NqwzIg6nU2LvA39Jdmqt3XaQ6hiOiIGIGFiyZEmb3TTrAk8OaT2miCSzB+iXtErSqWQX8kdryowCm9Ly1cATkU2aNgoMptFnq8gu2j/drM7J6yzpms6VwIu5Y1ybRpldBByLiMMF9M+sezw5pPWYjkeXRcQJSTcAO4F5wH0RsVfSNmAsIkaBe4GvSxon+wYzmPbdK+lB4CXgBPCViPgQoF6d6ZAjkpaQnR57DviTFH8UuIJs8MBx4Eud9s1sRmzc6KRiPcOzMHsWZjOzKfEszGZmVglOMmZmVhonGTMzK42TjJmZlcZJxszMSuMkY2ZmpXGSMTOz0jjJmJlZaZxkzMysNE4yZmZWGicZMzMrjZOMmZmVxknGzMxK4yRjZmalcZIxM7PSOMmYmVlpnGTMzKw0hSQZSesl7ZM0Lmlzne0LJD2Qtj8lqS+3bUuK75O0rlWdkkZS/EVJ90n6RIpfIumYpOfS48Yi+mZmZtPXcZKRNA+4E7gcWA1cI2l1TbHrgHci4jzgduC2tO9qYBBYA6wH7pI0r0WdI8CvA/8M+GXgy7nj/CAizk+PbZ32zczMOlPEN5m1wHhEvBIRHwA7gA01ZTYA29PyQ8DnJSnFd0TE+xHxKjCe6mtYZ0Q8GgnwNLC8gD6YmVkJikgyy4DXc+sTKVa3TEScAI4BpzfZt2Wd6TTZHwHfzYUvlvS8pMckrZluh8zMrBjzC6hDdWLRZplG8XrJr7bOu4AnI+IHaf1ZYGVEvCfpCuBhoL9ug6UhYAhgxYoV9YqYmVkBivgmMwGck1tfDhxqVEbSfOA04GiTfZvWKekmYAnw7yZjEfFuRLyXlh8FPiHpjHoNjojhiBiIiIElS5a031MzM5uSIpLMHqBf0ipJp5JdyB+tKTMKbErLVwNPpGsqo8BgGn22iuybx9PN6pT0ZWAdcE1E/GLyAJLOTtd5kLQ29e3tAvpnZmbT1PHpsog4IekGYCcwD7gvIvZK2gaMRcQocC/wdUnjZN9gBtO+eyU9CLwEnAC+EhEfAtSrMx3yq8BB4Icpp/xNGkl2NXC9pBPAz4HBlMjMzGyGaK7/OzwwMBBjY2Mz3Qwzs1lD0jMRMdBOWf/i38zMSuMkY2ZmpXGSMTOz0jjJmJlZaZxkzGbCyAj09cEpp2TPIyPl7mc2Q4r4xb+ZTcXICAwNwfHj2frBg9k6wMaNxe9nNoM8hNlDmK3b+vqyBFFr5Uo4cKD4/cwK5iHMZlX22mtTi3e6n9kMcpIx67ZGk7K2mqx1uvuZzSAnGbNuu+UWWLjw5NjChVm8jP3MZpCTjFmZ6o0G27gRhoezaylS9jw83PrifbP9POrMKsoX/n3h38pSOxoMsm8e7SSUKh7HLJnKhX8nGScZK0u3RoN51Jl1mUeXmVVBt0aDedSZVZiTjFlZujUazKPOrMKcZMzK0q3RYB51ZhVWSJKRtF7SPknjkjbX2b5A0gNp+1OS+nLbtqT4PknrWtWZbsn8lKT9qc5TWx3DbEZMdxRZVY9jNg0dJxlJ84A7gcuB1cA1klbXFLsOeCcizgNuB25L+64muxXzGmA9cJekeS3qvA24PSL6gXdS3Q2PYSWrwtDZKrShkY0bs4vvv/hF9tzOP/zT6c90jtMtVXh9qtCGuSoiOnoAFwM7c+tbgC01ZXYCF6fl+cBbgGrLTpZrVGfa5y1gfu2xGx2jVfsvuOCCsGn6xjciFi6MgI8eCxdm8bnUhiK5P73Zhh4DjEWbOaKI02XLgNdz6xMpVrdMRJwAjgGnN9m3Ufx04B9THbXHanQMK8vWrSf/NgOy9a1b51YbiuT+9GYb5rAikozqxGp/fNOoTFHxdtuRFZSGJI1JGjty5Ei9ItaOKgydrUIbiuT+9GYb5rAikswEcE5ufTlwqFEZSfOB04CjTfZtFH8L+HSqo/ZYjY7xMRExHBEDETGwZMmStjtqNaowdLYKbSiS+9ObbZjDikgye4D+NOrrVLIL+aM1ZUaBTWn5auCJdF5vFBhMI8NWAf3A043qTPv8baqDVOcjLY5hZanC0NkqtKFI7k9vtmEua/fiTbMHcAXwU+BlYGuKbQN+Py3/EvBXwDhZEjk3t+/WtN8+4PJmdab4uamO8VTnglbHaPbwhf8OfeMbEStXRkjZ80xcTK1CG4rk/vRmG3oIU7jw77nLPHeZlWlkJLvA/Npr2emZW24pZ3hxt45jxtTmLpvfuoiZTUvt7MgHD2brUO4szGUdx2wa/E3G32SsLJ6F2XqUZ2E2qwLPwmzmJGNWGs/CbOYkY1Yaz8Js5iRjVppmsyNPd8LGevt5FmarMF/494V/67ba0WCQffNolRimu59ZwaZy4d9JxknGum26o8E8iswqwqPLzKpsuqPBPIrMZiEnGbNum+5oMI8is1nIScas26Y7GsyjyGwWcpIx67bpjgbzKDKbhXzh3xf+zcymxBf+zcysEpxkzMysNE4yZmZWGicZMzMrTUdJRtJiSbsk7U/PixqU25TK7Je0KRe/QNKPJY1LukOSmtUraaOkF9Lj7yX9Zq6uA6mu5yT5Sr6ZWQV0+k1mM7A7IvqB3Wn9JJIWAzcBFwJrgZtyyehuYAjoT4/1Lep9FfidiPgN4GZguOZwn4uI89sd9WBmZuXqNMlsALan5e3AlXXKrAN2RcTRiHgH2AWsl7QU+FRE/DCycdT35/avW29E/H2qA+BHwPIO229mZiXqNMmcFRGHAdLzmXXKLANez61PpNiytFwbb7fe64DHcusBfE/SM5KGptEXMzMr2PxWBSQ9DpxdZ9PWNo+hOrFoEm9dofQ5siTzL3Ph34qIQ5LOBHZJ+oeIeLLB/kNkp+lY4XmfzMxK0zLJRMQXGm2T9IakpRFxOJ3+erNOsQngktz6cuD7Kb68Jn4oLTesV9JvAPcAl0fE27l2HkrPb0r6Ftn1n7pJJiKGSddzBgYG5vaUB2ZmJer0dNkoMDlabBPwSJ0yO4HLJC1KF/wvA3am02A/k3RRGlV2bW7/uvVKWgH8DfBHEfHTyQNI+hVJn5xcTsd4scO+mZlZh1p+k2nhVuBBSdcBrwFfBJA0APxJRHw5Io5KuhnYk/bZFhFH0/L1wNeAXya7vvJYs3qBG4HTgbvSaOcTaSTZWcC3Umw+8F8j4rsd9s3MzDrkCTI9QaaZ2ZR4gkwzM6sEJxkzMyuNk4yZmZXGScbMzErjJGNmZqVxkjEzs9I4yZiZWWmcZMzMrDROMmZmVhonGTMzK42TjJmZlcZJxszMSuMkY2ZmpXGSMTOz0jjJmJlZaZxkzMysNE4yZmZWmo6SjKTFknZJ2p+eFzUotymV2S9pUy5+gaQfSxqXdIfS/ZMb1SvpEknHJD2XHjfm6lovaV+qa3Mn/TIzs2J0+k1mM7A7IvqB3Wn9JJIWAzcBFwJrgZtyyehuYAjoT4/1bdT7g4g4Pz22pWPMA+4ELgdWA9dIWt1h38xmxsgI9PXBKadkzyMjM90is2nrNMlsALan5e3AlXXKrAN2RcTRiHgH2AWsl7QU+FRE/DAiArg/t3879eatBcYj4pWI+ADYkeowm11GRmBoCA4ehIjseWjIicZmrU6TzFkRcRggPZ9Zp8wy4PXc+kSKLUvLtfFW9V4s6XlJj0la0+IYdUkakjQmaezIkSOt+mjWPVu3wvHjJ8eOH8/iZrPQ/FYFJD0OnF1nU7vvetWJRZN4M88CKyPiPUlXAA+TnWabUl0RMQwMAwwMDLQ6pln3vPba1OJmFdcyyUTEFxptk/SGpKURcTid/nqzTrEJ4JLc+nLg+ym+vCZ+KC3XrTci3s2161FJd0k6I9V1ToO6zGaPFSuyU2T14mazUKeny0aBydFim4BH6pTZCVwmaVG64H8ZsDOdBvuZpIvSqLJrc/vXrVfS2bkRaGtT+98G9gD9klZJOhUYTHWYzS633AILF54cW7gwi5vNQp0mmVuBSyXtBy5N60gakHQPQEQcBW4mSwR7gG0pBnA9cA8wDrwMPNasXuBq4EVJzwN3AIOROQHcQJbQfgI8GBF7O+ybWfdt3AjDw7ByJUjZ8/BwFjebhZQN7Jq7BgYGYmxsbKabYWY2a0h6JiIG2inrX/ybmVlpnGTMzKw0TjJmZlYaJxkzMyuNk4yZmZXGScbMzErjJGPV4dmHbZLfCz2j5bQyZl0xOfvw5OSQk7MPg3+IONf4vdBT/GNM/xizGvr66s/ZtXIlHDjQ7dbYTPJ7ofL8Y0ybfTz7sE3ye6GnOMlYNTSaZdizD889fi/0FCcZqwbPPmyT/F7oKU4yVg2efdgm+b3QU3zh3xf+zcymxBf+zcysEpxkzMysNB0lGUmLJe2StD89L2pQblMqs1/Splz8Akk/ljQu6Y7crZXr1ivpzyQ9lx4vSvpQ0uK07UCq6zlJPv9lZlYBnX6T2Qzsjoh+YHdaP0lKAjcBFwJrgZtyyehuYAjoT4/1zeqNiP8QEedHxPnAFuDvcrdyBvhc2t7WuUIzMytXp0lmA7A9LW8HrqxTZh2wKyKORsQ7wC5gvaSlwKci4oeRjT64P7d/O/VeA3yzw/abmVmJOk0yZ0XEYYD0fGadMsuA13PrEym2LC3XxlvWK2kh2beev86FA/iepGckDU27R2ZmVpiWE2RKehw4u86mrW0eQ3Vi0STejt8D/nvNqbLfiohDks4Edkn6h4h4sm6DsiQ0BLDCvyI2MytNyyQTEV9otE3SG5KWRsThdPrrzTrFJoBLcuvLge+n+PKa+KG03KreQWpOlUXEofT8pqRvkV3/qZtkImIYGIbsdzKN+mdmZp3p9HTZKDA5WmwT8EidMjuByyQtShf8LwN2ptNgP5N0URpVdm1u/4b1SjoN+J2a2K9I+uTkcjrGix32zczMOtRpkrkVuFTSfuDStI6kAUn3AKRTWjcDe9JjW+401/XAPcA48DLwWLN6k6uA70XE/87FzgL+m6TngaeB70TEdzvsm5mZdcjTynhaGTOzKfG0MmazmW89bD3Et182qxLfeth6jL/JmFXJ1q0fJZhJx49ncbNZyEnGrEp862HrMU4yZlXiWw9bj3GSMasS33rYeoyTjFmV+NbD1mM8usysajZudFKxnuFvMmZmVhonGTMzK42TjJmZlcZJxszMSuMkY2ZmpXGSMTOz0jjJWMYz/5p9nD8XHfPvZMwz/5rV489FIXzTMt+0LPsf2sGDH4+vXAkHDnS7NWbV4M9FQ127aZmkxZJ2Sdqfnhc1KLcpldkvaVMufoGkH0sal3SHJKX4FyXtlfQLSQM1dW1J5fdJWpeLr0+xcUmbO+nXnOOZf80+zp+LQnR6TWYzsDsi+oHdaf0kkhYDNwEXAmuBm3LJ6G5gCOhPj/Up/iLwB8CTNXWtBgaBNansXZLmSZoH3AlcDqwGrkllrR2e+dfs4/y5KESnSWYDsD0tbweurFNmHbArIo5GxDvALmC9pKXApyLih5Gds7t/cv+I+ElE7GtwvB0R8X5EvAqMkyWutcB4RLwSER8AO1JZa4dn/jX7OH8uCtFpkjkrIg4DpOcz65RZBryeW59IsWVpuTbeTLO66sXrkjQkaUzS2JEjR1occg7wzL9mH+fPRSFaji6T9Dhwdp1N7d4PVnVi0SQ+nbrqJcuGdUXEMDAM2YX/FsecGzzzr9nH+XPRsZZJJiK+0GibpDckLY2Iw+n015t1ik0Al+TWlwPfT/HlNfFDLZozAZzTYJ9GcTMzmyGdni4bBSZHi20CHqlTZidwmaRF6YL/ZcDOdHrtZ5IuSqPKrm2wf+3xBiUtkLSKbLDA08AeoF/SKkmnkg0OGO2wb2Zm1qFOk8ytwKWS9gOXpnUkDUi6ByAijgI3kyWCPcC2FAO4HriH7AL+y8Bjaf+rJE0AFwPfkbQz1bUXeBB4Cfgu8JWI+DAiTgA3kCW0nwAPprJmZjaD/GNM/xjTzGxKuvZjTDMzs2bm/DcZSUeAOnNHtHQG8FbBzZkp7ks1uS/V5L7AyohY0k7BOZ9kpkvSWLtfF6vOfakm96Wa3Jep8ekyMzMrjZOMmZmVxklm+oZnugEFcl+qyX2pJvdlCnxNxszMSuNvMmZmVpo5n2S6feM1SX2Sfi7pufT46mztS9pW9yZyFe5L3XolXSLpWO51ubGAPjS9kV6aHumBtP0pSX25bVO6OV+aUump1K8H0vRKhelyX74m6dXca3F+kX0psT/3SXpT0os1dbX1Xp4lffkLSf8z99pc0bKBETGnH8C/Bzan5c3AbXXKLAZeSc+L0vKitO1psulvRDYtzuUp/k+BXyObDHQgV1cf8GKP9GU18DywAFhFNjXQvIr3pW69ZJO4frvA12Je+nucC5ya/k6ra8r8W+CraXkQeKDZ37VZnWTTLQ2m5a8C18/ivnwNuLqMz0hZ/Unb/hXwWWo+3+28l2dRX/4C+NOptHHOf5Oh+zdeK1NVbiJX2b60WW8R2rmRXr4tDwGfT9+4pnRzvrTP76Y6yuhX1/pSYJubKaM/RMSTwFE+rsz3XLf7MmVOMt2/8RrAKkn/Q9LfSfrt6TW7rqrcRK4IZfWlWb0XS3pe0mOS1nTY/nb+Nv+/TGSTvB4DTm+yb6P46cA/pjoaHasT3ezLpFskvSDpdkkLiuhEvbY2OPZJZdrsTzPtvJenq9t9AbghvTb3tXPqr+X9ZHqBqnXjtcPAioh4W9IFwMOS1kTEu201pFp9mc4+H+1crb48SzZVxnvpPPPDZLeSmK522jDV9je6OV9Hr0MbutkXgC3A/yI7/TMM/Dmwra2WtqeM/syUbvflbrJZ9SM9/0fgj5vtMCeSTFToxmsR8T7wflp+RtLLwGeAtqaCrlJfaH4TuZZmqC91680n+Yh4VNJdks6IiOnOUdXO32ayzISk+cBpZKcopnpzvreAT0uan/6nWvRN+7rZl8n/7QO8L+kvgT8toA/12lqvTbVlptKfRtp5L09XV/sSEW9MLkv6L8C3WzXQp8u6fOM1SUskzUvL55L9b/mVYrpSmZvIFaGsvtStV9LZqSyS1pJ9Nt7uoP3t3Egv35argSfSNaQp3Zwv7fO3qY6T+lWQrvUFIP1DTHo9rgROGuFU0f400857ebq62pfJ1ya5inZemyJGOMzmB9m5yd3A/vS8OMUHgHty5f6Y7MLYOPClXHwg/aFfBv4zH/3A9Sqy/ym8D7xB9o8fwL8B9pKN6ngW+L3Z2pe0bWsqv480gqvifWlU7w251+VHwL8ooA9XAD9NbdiaYtuA30/LvwT8VWr708C5rf6u9epM8XNTHeOpzgUFf0662ZcngB+n1+8bwD8psi8l9uebZKfD/2/6vFzX7D03S/vy9fTavECWpJa2ap9/8W9mZqXx6TIzMyuNk4yZmZXGScbMzErjJGNmZqVxkjEzs9I4yZiZWWmcZMzMrDROMmZmVpr/B69Cb5ftDZVlAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# The circle of least confusion is about 20 times smaller when using the aspheric lens\n",
-    "\n",
-    "%pylab inline\n",
-    "\n",
+    "# The circle of least confusion is about 10 times smaller when using the aspheric lens\n",
     "spot_diagram_c(CSph)\n",
     "figure()\n",
     "spot_diagram_c(CAsph)"
@@ -1980,41 +1359,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "025b33074f6e4dbdb9e1f684c8f47021",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-140.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "199.22609504309656\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/lib/python3/dist-packages/pyoptools/raytrace/calc/calc.py:67: RuntimeWarning: invalid value encountered in true_divide\n",
-      "  a=p2p1xv2/d1xd2\n",
-      "/usr/lib/python3/dist-packages/pyoptools/raytrace/calc/calc.py:68: RuntimeWarning: invalid value encountered in true_divide\n",
-      "  b=p2p1xv1/d1xd2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Lenses choice: We look in the catalogue for the appropriate objective lens\n",
     "\n",
@@ -2048,8 +1395,8 @@
     "\n",
     "L1=library.Edmund.get(\"45179\") #f=200 r= 25\n",
     "\n",
-    "RP1=RightAnglePrism(width=55,height=55,material=material.schott[\"SK5\"])\n",
-    "RP2=RightAnglePrism(width=40,height=40,material=material.schott[\"SK5\"])\n",
+    "RP1=RightAnglePrism(width=55,height=55,material=material.schott[\"N-SK5\"])\n",
+    "RP2=RightAnglePrism(width=40,height=40,material=material.schott[\"N-SK5\"])\n",
     "\n",
     "CC=CCD(size=(50,50))\n",
     "\n",
@@ -2069,37 +1416,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "272ec2947da14a3499d28507997024ff",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Renderer(camera=OrthographicCamera(bottom=-125.0, children=(DirectionalLight(intensity=0.7, position=(0.0, 100…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "(array([ -0.30308561,   0.16838089, 112.35061491]),\n",
-       " array([ -0.22400544,   0.17422645, 112.32427176]),\n",
-       " 0.08355719714347722,\n",
-       " False)"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Looking for the right eyepiece configuration\n",
     "\n",
@@ -2133,8 +1452,8 @@
     "L2=library.Edmund.get(\"45175\") # f=30 ; r=10  \n",
     "\n",
     "\n",
-    "RP1=RightAnglePrism(width=55,height=55,material=material.schott[\"SK5\"])\n",
-    "RP2=RightAnglePrism(width=40,height=40,material=material.schott[\"SK5\"])\n",
+    "RP1=RightAnglePrism(width=55,height=55,material=material.schott[\"N-SK5\"])\n",
+    "RP2=RightAnglePrism(width=40,height=40,material=material.schott[\"N-SK5\"])\n",
     "\n",
     "\n",
     "CC=CCD(size=(50,50))\n",
@@ -2176,8 +1495,8 @@
     "## Aberrated optical system:\n",
     "\n",
     "## We place a CCD named HOLO between the two lenses \n",
-    "L2=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"BK7\"])\n",
-    "L3=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"BK7\"])\n",
+    "L2=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"N-BK7\"])\n",
+    "L3=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"N-BK7\"])\n",
     "\n",
     "C=CCD()\n",
     "\n",
@@ -2190,7 +1509,9 @@
     "\n",
     "S.ray_add(R)\n",
     "S.propagate()\n",
-    "Plot3D(S,center=(0,0,100),size=(250,100),scale=4,rot=[(0,pi/2.05,0)])"
+    "\n",
+    "#The plot is too slow due the high amount of rays\n",
+    "#Plot3D(S,center=(0,0,100),size=(250,100),scale=4,rot=[(0,pi/2.05,0)])"
    ]
   },
   {
@@ -2214,8 +1535,8 @@
     "\n",
     "fi=210\n",
     "\n",
-    "L2=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"BK7\"])\n",
-    "L3=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"BK7\"])\n",
+    "L2=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"N-BK7\"])\n",
+    "L3=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"N-BK7\"])\n",
     "\n",
     "C=CCD()\n",
     "\n",
@@ -2228,7 +1549,8 @@
     "\n",
     "S.ray_add(R)\n",
     "S.propagate()\n",
-    "Plot3D(S,center=(0,0,100),size=(250,100),scale=4,rot=[(0,pi/2.05,0)])"
+    "#The plot is too slow due the high amount of rays\n",
+    "#Plot3D(S,center=(0,0,100),size=(250,100),scale=4,rot=[(0,pi/2.05,0)])"
    ]
   },
   {
@@ -2271,14 +1593,14 @@
     "\n",
     "fi=210\n",
     "\n",
-    "L2=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"BK7\"])\n",
-    "L3=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"BK7\"])\n",
+    "L2=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"N-BK7\"])\n",
+    "L3=SphericalLens(radius=25,curvature_s1=1./100.,curvature_s2=-1./100,thickness=10,material=material.schott[\"N-BK7\"])\n",
     "\n",
     "C=CCD()\n",
     "\n",
     "S=System(complist=[(L2,(0,0,100),(0,0,0)),(DG,(0,0,110),(0,0,0)),(L3,(0,0,120),(0,0,0)),(C,(0,0,fi),(0,0,0))],n=1)\n",
     "\n",
-    "R=point_source_p(origin=(0.,0.,0),direction=(0,0.,0),span=pi/14,num_rays=(50,50),wavelength=0.470, label=\"blue\")\n",
+    "R=point_source_p(origin=(0.,0.,0),direction=(0,0.,0),span=pi/14,num_rays=(10,10),wavelength=0.470, label=\"blue\")\n",
     "\n",
     "S.ray_add(R)\n",
     "S.propagate()\n",
@@ -2319,9 +1641,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2333,7 +1655,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,

--- a/debian/changelog
+++ b/debian/changelog
@@ -45,4 +45,10 @@ pyoptools (0.1.1) UNRELEASED; urgency=medium
   [  ]
   * Paquete de prueba generado
 
+  [  ]
+  * Paquete de prueba generado
+
+  [  ]
+  * Paquete de prueba generado
+
  --  <richi@odin>  Sun, 04 Aug 2019 13:47:47 -0500


### PR DESCRIPTION
As reported in #105 the tutorial file was not running. This was fixed, and even thought the Tutorial.1.ipynb is far from being complete or well explained it now runs. Most of the examples were already running in the readthedocs documentation. Some time ago, an aliases "library" was implemented, so the short names for materials could be defined there (as an alias to the "real" material), without affecting the refractiveindex.info database. For the moment, adding a deprecation warning  (as requested in #105) is not easy to implement. A new material class "Tabulated_N" was added to include some materials defined in the database that do not have an equation defined.

Fix #105