### PR TITLE
Raise meaningful error when the aperture radius is too large

### DIFF
--- a/pyoptools/raytrace/_comp_lib/spherical_lens.py
+++ b/pyoptools/raytrace/_comp_lib/spherical_lens.py
@@ -86,6 +86,12 @@ class SphericalLens(Component):
         self.curvature_s1 = curvature_s1
         self.curvature_s2 = curvature_s2
 
+        if self.radius * self.curvature_s1 > 1:
+            raise ValueError("Aperture radius can not be larger than s1 curvature radius")
+
+        if self.radius * self.curvature_s2 > 1:
+            raise ValueError("Aperture radius can not be larger than s2 curvature radius")
+
         if self.curvature_s1 != 0.0:
             __a_surf = Spherical(
                 shape=Circular(radius=self.radius), curvature=self.curvature_s1


### PR DESCRIPTION
Fixes #59.
To test:
```python
from pyoptools.all import *
d1 = 10.0  # lens diameter
r1 = 5.0000  # first surface curvature radius
c1 = 1.0 / r1
c2 = 0
t1 = 1.5  # mm
n1 = material.corning["C79-80"]

# Mistake (forgot to divide diameter by 2 to get the radius).
L1=SphericalLens(radius=d1, curvature_s1=c1, curvature_s2=c2, thickness=t1, material=n1)
print("Focal lengths @587.6nm", L1.paraxial_constants(0.5876))

S=S=System(complist=[(L1,(0,0,0),(0,0,0))])
```
Raises this error now:
```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-d61af8462154> in <module>
      6 n1 = material.corning["C79-80"]
      7 
----> 8 L1=SphericalLens(radius=d1, curvature_s1=c1, curvature_s2=c2, thickness=t1, material=n1)
      9 print("Focal lengths @587.6nm", L1.paraxial_constants(0.5876))
     10 

~/.venv/pyoptools/lib64/python3.6/site-packages/pyoptools/raytrace/_comp_lib/spherical_lens.py in __init__(self, radius, thickness, curvature_s1, curvature_s2, *args, **kwargs)
     88 
     89         if self.radius * self.curvature_s1 > 1:
---> 90             raise ValueError("Aperture radius can not be larger than s1 curvature radius")
     91 
     92         if self.radius * self.curvature_s2 > 1:

ValueError: Aperture radius can not be larger than s1 curvature radius
```