### PR TITLE
Simplify setup.py; enable build for Windows, MacOS and every major Linux system; add actions to build wheel files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,39 @@
+name: Build Package
+
+on: push
+
+jobs:
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-11]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel twine
+        pip install Cython==0.29.30 --install-option="--no-cython-compile"
+        pip install numpy==1.21.6 cibuildwheel
+    - name: Build sdist
+      run: python setup.py sdist --formats=gztar,zip
+    - name: Build wheels
+      run: |
+        python -m cibuildwheel --output-dir dist/
+      env:
+        CIBW_BUILD: "cp37* cp38* cp39* cp310*"
+        CIBW_SKIP: "*_i686 *musllinux* pp*"
+    - name: Upload Distributions
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: |
+          dist/*.whl
+          dist/*.tar.gz
+          dist/*.zip
+        retention-days: 7

--- a/pyoptools/raytrace/mat_lib/mat_eq.py
+++ b/pyoptools/raytrace/mat_lib/mat_eq.py
@@ -188,7 +188,7 @@ def from_yml(filename):
     """Create a material instance from a YML file as defined at
     https://refractiveindex.info/about
     """
-    with open(filename) as f:
+    with open(filename, encoding='utf-8') as f:
         mat = yaml.load(f, Loader=yaml.FullLoader)
 
     for c in mat["DATA"]:

--- a/pyoptools/wavefront/field/field.pyx
+++ b/pyoptools/wavefront/field/field.pyx
@@ -50,9 +50,6 @@ from pyoptools.misc.cmisc.cmisc import unwrap
 cdef extern from "math.h":
     double M_PI
     double sqrt(double)
-cdef extern from "complex.h":
-    double complex cexp(double complex)
-    double complex I
 
 cimport numpy as np
 cimport cython
@@ -307,8 +304,8 @@ cdef class Field:
                 R2=xd*xd+yd*yd+z*z
                 R=sqrt(R2)
                 R3=R2*R
-                ikR=I*k*R
-                result[i, j]=((z/(2.*M_PI*R3))*cexp(ikR)*(1.-ikR))
+                ikR=1j*k*R
+                result[i, j]=((z/(2.*M_PI*R3))*exp(ikR)*(1.-ikR))
 
         return result
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy==1.21.6", "Cython==0.29.30"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,140 +1,29 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import sys
-import os
-from setuptools import setup
-from setuptools.extension import Extension
 
-try:
-    from Cython.Build import cythonize
-    from Cython.Distutils import build_ext
-except ImportError:
-    print("You don't seem to have Cython installed. Please get a")
-    print("copy from www.cython.org and install it")
-    sys.exit(1)
+from setuptools import setup, find_packages
+from Cython.Build import cythonize
+from Cython.Build.Dependencies import default_create_extension
+
+import numpy
 
 
-# Look for paths containing arrayobject.h
-# Necessary for non-unix systems
-def contains_arrayobject_h(path):
-    """
-    Returns True if the python path string contains the arrayobject.h
-    include file where it is supposed to be.
-    """
-    f = False
-    try:
-        _s = os.stat(
-            os.path.join(path, "numpy", "core", "include", "numpy", "arrayobject.h")
-        )
-        f = True
-    except OSError:
-        pass
-    return f
+def create_extension(template, kwds: dict):
+    define_macros = kwds.get("define_macros", [])
 
+    if sys.platform in ("darwin", "win32"):
+        define_macros.append(("CYTHON_INLINE", ""))
+    
+    kwds["define_macros"] = define_macros
+    return default_create_extension(template, kwds)
 
-# scan the directory for extension files, converting
-# them to extension names in dotted notation
-def scandir(dir_, files=[]):
-    for file in os.listdir(dir_):
-        if file == "venv":
-            continue
-        path = os.path.join(dir_, file)
-        if os.path.isfile(path) and path.endswith(".pyx"):
-            files.append(path.replace(os.path.sep, ".")[2:-4])
-        elif os.path.isdir(path):
-            scandir(path, files)
-    return files
-
-
-def findpackages(dir_, files=[]):
-    for file in os.listdir(dir_):
-        if file in ["build", "venv"]:
-            continue
-        path = os.path.join(dir_, file)
-        if os.path.isdir(path):  # and path.endswith(".py"):
-            for file1 in os.listdir(path):
-                if file1 == "__init__.py":
-                    files.append(path.replace(os.path.sep, ".")[2:])
-            findpackages(path, files)
-    return files
-
-
-# generate an Extension object from its dotted name
-def makeExtension(extName):
-    extPath = extName.replace(".", os.path.sep) + ".pyx"
-    return Extension(
-        extName,
-        [extPath],
-        # adding the '.' to include_dirs is CRUCIAL!!
-        include_dirs=[".", include_numpy_array],
-        extra_compile_args=["-O3", "-Wall"],
-        # extra_link_args = ['-g'],
-        # libraries = ["dv",],
-    )
-
-
-# Check the availability of arrayobject.h
-valid_paths = list(filter(contains_arrayobject_h, sys.path))
-if len(valid_paths) == 0:
-    print("No paths in the python path contain numpy/arrayobject.h")
-    sys.exit(0)
-
-# The base path is by default the first python path with arrayobject.h in it.
-include_numpy_array = valid_paths[0]
-
-if len(valid_paths) > 1:
-    print(
-        "There are several valid include directories" "containing numpy/arrayobject.h"
-    )
-    l = [("%d: %s" % (i + 1, valid_paths[i])) for i in range(0, len(valid_paths))]
-    s = -1
-    print("\n".join(l))
-    # Prompt the user with a list of selections.
-
-    # Fix input for Python 3-3
-    try:
-        input = raw_input
-    except NameError:
-        pass
-
-    while not (s >= 1 and s <= len(valid_paths)):
-        try:
-            s = input("Selection [default=1]: ")
-        except EOFError:
-            s = 1
-            print("Selection is", s)
-            continue
-        if s == "":
-            s = 1
-        else:
-            s = int(s)
-    include_numpy_array = valid_paths[s - 1]
-
-# Add the children directory path suffix to the base path.
-include_numpy_array = os.path.join(include_numpy_array, "numpy", "core", "include")
-
-# Need to create a pyOpTools package
-extNames = scandir("./")
-
-# and build up the set of Extension objects
-extensions = [makeExtension(name) for name in extNames]
 
 setup(
     name="pyoptools",
     version="0.1.1",
-    packages=findpackages("./"),
+    packages=find_packages(exclude=["tests"]),
     scripts=["ipyoptools"],
-    # The names from pipy are used, not the deb package names
-    # requires=['numpy',
-    #          'cython',
-    #          'PyOpenGl',
-    #          'ipython',
-    #          'scipy',
-    #          'six',
-    #          ],
     package_data={
-        # 'pyoptools.raytrace.mat_lib': ['data/*.mat'],
         "pyoptools.raytrace.mat_lib": [
             "data/glass/*",
             "data/glass/*/*",
@@ -151,16 +40,7 @@ setup(
     license="GPLv3",
     url="https://github.com/cihologramas/pyoptools/",
     download_url="https://github.com/cihologramas/pyoptools/archive/v0.1.1.zip",
-    ext_modules=cythonize(extensions),
-    cmdclass={"build_ext": build_ext},
-    #      data_files=[("share/doc/pyoptools/examples/basic_course",
-    #                   ["examples/basic_course/00-Introducción.ipynb",
-    #                    "examples/basic_course/03-SimpleComponents.ipynb",
-    #                    "examples/basic_course/05-Autocollimator.ipynb",
-    #                    "examples/basic_course/01-IntroPython.ipynb",
-    #                    "examples/basic_course/04-PredefinedComponents.ipynb",
-    #                    "examples/basic_course/06-GeomWF.ipynb",
-    #                    "examples/basic_course/02-Surfaces.ipynb",
-    #                    "examples/basic_course/04-Simple RayTraces.ipynb",
-    #                    "examples/basic_course/07-SimpleEODs.ipynb"])]
+    ext_modules=cythonize("pyoptools/**/*.pyx", language_level="2", create_extension=create_extension),
+    include_dirs=[numpy.get_include()],
+    install_requires=['numpy', 'scipy', 'imageio', 'PyYAML', 'matplotlib'],
 )


### PR DESCRIPTION
The major goal for this pull request is to be able to compile pyoptools for Windows, MacOS and any major Linux system.

### setup.py
This file was simplified and uses the Cython functionality to compile the given files. There is a problem with MacOS and Windows compilers not supporting inline on data declarations - in this case the `CYTHON_INLINE` macro is redefined.

### Github Actions
With the added workflow packages are automatically build for Windows, MacOS and Linux for Python3.7, 3.8, 3.9 and 3.10.

### Others
* `mat_eq.py` needs an 'utf-8' encoding argument when opening files. Otherwise Windows falls back to CP-1252 encoding.
* `field.pyx` changes definitions for `I` and `cexp` which is not working with Windows compiler

## Next steps (will be pull requests, when this one is accepted)
* Automatically push packages to pypi on releases (Imagine `pip install pyoptools` on any platform... :-) )
* Redo installation documentation (as it will be much easier at that state)
* Fix unittests and run them in github actions
* Cleanup of old (and probably unused) scripts and files in root folder
* Make fixes to use Cython language_level "3" (currently it's based on Python 2 syntax)
* ...
