### PR TITLE
Fix typos found in the code base 

### DIFF
--- a/Tutorial/Tutorial.1.ipynb
+++ b/Tutorial/Tutorial.1.ipynb
@@ -486,7 +486,7 @@
     "\n",
     "    \n",
     "\n",
-    "In appearance, stops and CCDs look exactly like optical surfaces but when interacting with rays they show different propperties.\n",
+    "In appearance, stops and CCDs look exactly like optical surfaces but when interacting with rays they show different properties.\n",
     "    "
    ]
   },

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -5,7 +5,7 @@ Developing Information
 Doc strings
 -----------
 
-The :doc:`old <development_old>` proposed way to document pyOpTools was confusing and should not be used any more. From now on all the documentation should be written in the `NumPy Style Python Docstrings <https://www.sphinx-doc.org/en/master/usage/extensions/example_numpy.html>`_. This style was chossen because it allows to easily document function and methods with multiple return values (return tuples).
+The :doc:`old <development_old>` proposed way to document pyOpTools was confusing and should not be used any more. From now on all the documentation should be written in the `NumPy Style Python Docstrings <https://www.sphinx-doc.org/en/master/usage/extensions/example_numpy.html>`_. This style was chosen because it allows to easily document function and methods with multiple return values (return tuples).
 
 See also: `<https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_
 
@@ -15,7 +15,7 @@ Creating :class:`Surface` Subclasses
 The following care must be taken when creating a :class:`Surface` subclass:
 
 #. All surfaces super classes must be picklable. To do this follow:
-    #. All subclases inherit from pyoptools.picklable.picklable.Picklable
+    #. All subclasses inherit from pyoptools.picklable.picklable.Picklable
     #. For cython subclasses register all the attributes that affect the state using self.addkey("key")
         where key is changed by the attribute key.
     #. For python subclasses nothing needs to be done

--- a/doc/manual.lyx
+++ b/doc/manual.lyx
@@ -70,12 +70,12 @@ misc Package containing auxiliary functions
 \end_layout
 
 \begin_layout Description
-ray_trace Package containing clases and routines used to simulate 3D non-secuent
+ray_trace Package containing classes and routines used to simulate 3D non-secuent
 ial, physical raytrace of optical systems.
 \end_layout
 
 \begin_layout Description
-wavefront Package containing clases and routines used to simulate the propagatio
+wavefront Package containing classes and routines used to simulate the propagatio
 n of wavefronts through optical systems
 \end_layout
 
@@ -558,7 +558,7 @@ system Package that is used to describe the optical systems to be simulated.
 \end_layout
 
 \begin_layout Description
-material Package that defines tha class that describe the phisical characteristi
+material Package that defines the class that describes the physical characteristi
 cs of the materials used to create the optical components.
 \end_layout
 

--- a/pyoptools/raytrace/_comp_lib/aspheric_lens.py
+++ b/pyoptools/raytrace/_comp_lib/aspheric_lens.py
@@ -176,7 +176,7 @@ class AsphericLens(Component):
         """Adds an outer brim surface defined by surface definition defn.
         Only applies is the specified outer diameter of this lens is larger
         than the maximum diameter of the defined surface.
-        Brim will be located at postion z_position.
+        Brim will be located at position z_position.
         """
         if self.outer_diameter > defn.diameter:
             brim = Aperture(

--- a/pyoptools/raytrace/_comp_lib/ccd.py
+++ b/pyoptools/raytrace/_comp_lib/ccd.py
@@ -34,7 +34,7 @@ from pyoptools.raytrace.shape import Rectangular
 class CCD(Component):
     """Class to define a CCD like detector
 
-    :param size: Tuple with the phisical size (sx,sy)  of the CCD chip
+    :param size: Tuple with the physical size (sx,sy)  of the CCD chip
     :type size: tuple(float, float)
     :param transparent: Boolean to set the detector transparent characteristic.
         Not implemented

--- a/pyoptools/raytrace/comp_lib.py
+++ b/pyoptools/raytrace/comp_lib.py
@@ -6,7 +6,7 @@ some standard optical components, and return an instance to such components.
 This module hides from the end user un needed stuff.
 """
 
-# sorted is used so the clases are ordered alphabetically in the sphinx docs
+# sorted is used so the classes are ordered alphabetically in the sphinx docs
 __all__ = sorted(
     [
         "SphericalLens",

--- a/pyoptools/raytrace/component/component.pyx
+++ b/pyoptools/raytrace/component/component.pyx
@@ -216,7 +216,7 @@ cdef class Component(Picklable):
         Distance length from a ray origin to a component, following the ray path.
 
         Method that calculates the distance traveled by a ray from its origin to
-        the next surface of the component. It returns the phisical distance, not
+        the next surface of the component. It returns the physical distance, not
         the optical distance
 
 

--- a/pyoptools/raytrace/ray/ray.pyx
+++ b/pyoptools/raytrace/ray/ray.pyx
@@ -399,7 +399,7 @@ cdef class Ray:
             repr(self.label)+",orig_surf="+repr(self.orig_surf)+", order="+repr(self.order)+")"
 
     def add_child(self, cr):
-        '''Add childs to the current ray, and create the appropiate links
+        '''Add childs to the current ray, and create the appropriate links
 
         *cr*
             Ray to include in the child list

--- a/pyoptools/raytrace/surface/__init__.py
+++ b/pyoptools/raytrace/surface/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
-"""Module that defines all the clases that describe the optical surfaces
+"""Module that defines all the classes that describe the optical surfaces
 """
 
 from .surface import Surface

--- a/pyoptools/raytrace/surface/detector.pyx
+++ b/pyoptools/raytrace/surface/detector.pyx
@@ -40,7 +40,7 @@ cdef class ArrayDetector(Plane):
         >>> cs=ArrayDetector(size=(10,10))
     '''
 
-    # CCD phisical size
+    # CCD physical size
     #size=Tuple(Float(10), Float(10))
     cdef public tuple size
 
@@ -69,7 +69,7 @@ cdef class ArrayDetector(Plane):
         Parameter:
 
         *size*
-            Size of the detector in pixels. The phisical size of the detector is
+            Size of the detector in pixels. The physical size of the detector is
             given at the surface creation.
         """
         px, py = size
@@ -93,7 +93,7 @@ cdef class ArrayDetector(Plane):
         Parameter:
 
         *size*
-            Size of the detector in pixels. The phisical size of the detector is
+            Size of the detector in pixels. The physical size of the detector is
             given at the surface creation.
         """
         px, py = size

--- a/pyoptools/raytrace/surface/plane_mask.pyx
+++ b/pyoptools/raytrace/surface/plane_mask.pyx
@@ -152,7 +152,7 @@ cdef class RPPMask(Surface):
             oz2 = rz**2 - 2*M*l/d*(rx*kx+ry*ky)-(M*l/d)**2
 
             if oz2 < 0:
-                print "warning: eliminating not phisically possible ray"
+                print "warning: eliminating physically impossible ray"
                 ret.append(Ray(pos=PI, dir=ri.dir,
                                intensity=0,
                                wavelength=ri.wavelength, n=ni, label=ri.label, orig_surf=self.id))

--- a/pyoptools/raytrace/surface/surface.pyx
+++ b/pyoptools/raytrace/surface/surface.pyx
@@ -111,7 +111,7 @@ cdef class Surface(Picklable):
         '''Method that returns the topography of the surface
 
         The matrix returned is :math:`z=f(x,y)`. This method mus be overloaded in all
-        subclases of Surface.
+        subclasses of Surface.
         '''
         warn("Method topo, from class Surface, should be overloaded" +
              " in class "+self.__class__.__name__)
@@ -146,7 +146,7 @@ cdef class Surface(Picklable):
         This method returns the normal vector at a specific intersection point,
         given by ip. The normal vector must be normalized.
 
-        This method must be overloaded in all Surface subclases. It contains
+        This method must be overloaded in all Surface subclasses. It contains
         the geometric specific code.
 
         **Arguments:**
@@ -211,7 +211,7 @@ cdef class Surface(Picklable):
 
         iray must be in the coordinate system of the surface
 
-        This function must be overloaded in all :class:`Surface` subclases.
+        This function must be overloaded in all :class:`Surface` subclasses.
         It contains the geometric specific code. It must not  check for
         the aperture.
 

--- a/pyoptools/raytrace/system/system.pyx
+++ b/pyoptools/raytrace/system/system.pyx
@@ -642,7 +642,7 @@ cdef class System(Picklable):
         """Distance length from a ray origin to a subsystem, following the ray path.
 
         Method that calculates the distance traveled by a ray from its origin to
-        the next surface of the component. It returns the phisical distance, not
+        the next surface of the component. It returns the physical distance, not
         the optical distance
 
 

--- a/pyoptools/wavefront/field/field.pyx
+++ b/pyoptools/wavefront/field/field.pyx
@@ -99,7 +99,7 @@ cdef class Field:
         amp_im Filename of the image containing the amplitude of the
                field
         ph_im  Filename of the image containing the phase of the field
-        amp_n  Floating point number used to normalize the amplitud
+        amp_n  Floating point number used to normalize the amplitude
                1/255. by default
         ph_n   Floating point number used to normalize the phase.
                2*pi/255 by default.


### PR DESCRIPTION
Found via `codespell -q3 -L childs,clen,componentes,mater,nd,querry,ser,utiliza`