### PR TITLE
Fix typos

### DIFF
--- a/Tutorial/Tutorial.ipynb
+++ b/Tutorial/Tutorial.ipynb
@@ -214,7 +214,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Example 2.3: Circular cilynders with different shapes\n",
+    "# Example 2.3: Circular cylinders with different shapes\n",
     "\n",
     "S1=Cylinder(radius=36,length=100,reflectivity=1)\n",
     "S2=Cylindrical(shape=Circular(radius=(50)),curvature=1/100.)\n",
@@ -573,14 +573,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A glass block of refractive index *n*  and a beamsplitter whose hipotenuse reflectivity is *R*  are created as follows:\n",
+    "A glass block of refractive index *n*  and a beamsplitter whose hypotenuse reflectivity is *R*  are created as follows:\n",
     "\n",
     "```python\n",
     "    B=Block(size=(a,b,c), material=n)\n",
     "    BS=BeamSplitingCube(size= l, reflectivity=R, material= n)\n",
     "```\n",
     "\n",
-    "To create a right angle prism of dimensions *w* and *h* and hipotenuse of reflectivity of *R*  and a penta-prism of side *l* and refractive index *n*:\n",
+    "To create a right angle prism of dimensions *w* and *h* and hypotenuse of reflectivity of *R*  and a penta-prism of side *l* and refractive index *n*:\n",
     "\n",
     "```python\n",
     "    RP=RightAnglePrism(width=w,height=h,material=n,reflectivity=R)\n",
@@ -610,7 +610,7 @@
    "source": [
     "y # 4. Optical systems <a class=\"anchor\" id=\"4\"></a>\n",
     "\n",
-    "In order to make ray tracing, *pyOpTools* uses the class *System*. A System is constitued by a set of optical components properly arranged and a light rays.\n",
+    "In order to make ray tracing, *pyOpTools* uses the class *System*. A System is constituted by a set of optical components properly arranged and a light rays.\n",
     "\n",
     "By adding a CCD anywhere in the optical path it is possible to visualize the profile of the beam as it would be captured by an optical sensor."
    ]
@@ -668,7 +668,7 @@
    "source": [
     "## 4.2 Rays <a class=\"anchor\" id=\"42\"></a>\n",
     "\n",
-    "In *pyOpTools* a ray is an object characterised by its origin coordinates (x,y,z), its direction in cartesian coordinates (ux,uy,uz), its intensity, and its wavelength in $\\mu$m.\n",
+    "In *pyOpTools* a ray is an object characterized by its origin coordinates (x,y,z), its direction in cartesian coordinates (ux,uy,uz), its intensity, and its wavelength in $\\mu$m.\n",
     "\n",
     "```python\n",
     "    R=Ray(pos=(x,y,z),dir=(ux,uy,uz),intensity=I,wavelength=lambda)\n",

--- a/doc/notebooks/basic/Autocollimator.ipynb
+++ b/doc/notebooks/basic/Autocollimator.ipynb
@@ -58,7 +58,7 @@
     "In this example, the ray trace proceesd as follow:\n",
     "\n",
     "1. 25 rays come out from a the point source (**R**) \n",
-    "2. They enter the beam splitting cube (**BS**), and propagate to the **BS** reflective surface. In the first interfase of **BS** the rays get diffracted.\n",
+    "2. They enter the beam splitting cube (**BS**), and propagate to the **BS** reflective surface. In the first interface of **BS** the rays get diffracted.\n",
     "3. In the reflective surface, the original rays continue propagating, and a new set of rays (reflected) get created.\n",
     "4. The set of reflected rays get propagated out of the cube, and do not get propagated anymore as there are no optical components they can intersect.\n",
     "5. The transmitted rays get propagated out of the cube, until they intersect the lens (**L**).\n",
@@ -115,7 +115,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this case we see that the spot is hitting the CCD approximatelly at (0mm, 0.0025 mm).\n",
+    "In this case we see that the spot is hitting the CCD approximately at (0mm, 0.0025 mm).\n",
     "\n",
     "Some times getting an approximate position of the center of the spot from a plot is not enough. In such cases we can use the [hit_list](../../pyoptools.raytrace.comp_lib.rst#pyoptools.raytrace.comp_lib.CCD.hit_list) property from the **CCD**. From this list we can get the intersection point of each ray and for example use the average in X and in Y to estimate the spot centroid position."
    ]

--- a/doc/notebooks/basic/GeomWF.ipynb
+++ b/doc/notebooks/basic/GeomWF.ipynb
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "TODO: When generating the documentation automatically, the methods related to get_optical_path_map... are not working. If the example is run in a normal notebook tthey work. I dont understand what is the problem. Needs to be fixed."
+    "TODO: When generating the documentation automatically, the methods related to get_optical_path_map... are not working. If the example is run in a normal notebook they work. I don't understand what is the problem. Needs to be fixed."
    ]
   },
   {

--- a/pyoptools/misc/GS/gs.py
+++ b/pyoptools/misc/GS/gs.py
@@ -167,7 +167,7 @@ def gs(idata, itera=10, ia=None):
 
 
 def gs_mod(idata, itera=10, osize=256):
-    """Modiffied Gerchberg-Saxton algorithm to calculate DOEs
+    """Modified Gerchberg-Saxton algorithm to calculate DOEs
 
     Calculates the phase distribution in a object plane to obtain an
     specific amplitude distribution in the target plane. It uses a

--- a/pyoptools/misc/Poly1Drot/Poly1Drot.pyx
+++ b/pyoptools/misc/Poly1Drot/Poly1Drot.pyx
@@ -20,10 +20,10 @@ cdef class poly1DrotDeriv:
     def __init__(self, coef, wrt):
         """Initilizer for a rotationally symmetric 1D polynomial derivative
 
-        Paramerers
+        Parameters
         ----------
         coef : tuple of float
-            All the coeffiecents starting from index 0
+            All the coefficients starting from index 0
         wrt: int
             Selector for the axis to find the derivative with respect to.
             Either 0 or 1 for the x or y axis respectively. Other values
@@ -83,10 +83,10 @@ cdef class poly1Drot:
         This can be evaluated at any point x, y in the same way as a 2D
         polynomial.
 
-        Paramerers
+        Parameters
         ----------
         coef : tuple of float
-            All the coeffiecents starting from index 0
+            All the coefficients starting from index 0
         """
 
         self.coef = np.array(coef, dtype=np.float64)

--- a/pyoptools/paraxial/systemp.py
+++ b/pyoptools/paraxial/systemp.py
@@ -153,7 +153,7 @@ class PSystem:  # (MutableSequence):
 
     def get_matrix(self, ua=False):
         """Get total system matrix
-        if ua == True, stop at the firs system aperture found
+        if ua == True, stop at the first system aperture found
         """
         na = self.surfaces[0].n
         mat = array(((1, 0), (0, 1)))

--- a/pyoptools/raytrace/_comp_lib/cube.py
+++ b/pyoptools/raytrace/_comp_lib/cube.py
@@ -89,9 +89,9 @@ class BeamSplittingCube(System):
 
     :param size: Side dimension of the cube
     :type size: float
-    :param reflectivity: Reflectivity of the hypothenuse (between 0 and 1).
+    :param reflectivity: Reflectivity of the hypotenuse (between 0 and 1).
     :type reflectivity: float
-    :param material: Material used to make the cube. Usedto calculate the
+    :param material: Material used to make the cube. Used to calculate the
        refraction index of the cube
     :type material: float or
        :class:`~pyoptools.raytrace.mat_lib.material.Material` subclass instance

--- a/pyoptools/raytrace/_comp_lib/optic_factory.py
+++ b/pyoptools/raytrace/_comp_lib/optic_factory.py
@@ -8,13 +8,13 @@ from inspect import signature
 def optic_factory(**kwargs):
     """Returns a new optical component, given dictionary descriptor
 
-    Descriptor should countain all the keyword arguments for a
+    Descriptor should contain all the keyword arguments for a
     optical component constructor.
 
     Descriptor should contain a 'type' element with string for the
     optical component class name.
 
-    Only elements with keyword arguments explicitely defined by the
+    Only elements with keyword arguments explicitly defined by the
     optical component class will be passed through to the constructor.
     """
     try:

--- a/pyoptools/raytrace/_comp_lib/prism.py
+++ b/pyoptools/raytrace/_comp_lib/prism.py
@@ -38,7 +38,7 @@ class RightAnglePrism(Component):
         height       Height of the prism face
         material     To calculate the refraction index of the prism (inherited
                      from component)
-        reflectivity Reflectivity of the coating of the hipotenuse. For a normal
+        reflectivity Reflectivity of the coating of the hypotenuse. For a normal
                      prism it is 0. Note: Total internal reflection works in the
                      prism.
         reflega      Reflectivity of the Leg A of the prism. For a normal prism
@@ -47,7 +47,7 @@ class RightAnglePrism(Component):
                      it is 0.
         ============ ===========================================================
 
-    The origin of the coordinate system is located at the center of hipotenuse
+    The origin of the coordinate system is located at the center of hypotenuse
     face of the prism
     """
 

--- a/pyoptools/raytrace/component/component.pyx
+++ b/pyoptools/raytrace/component/component.pyx
@@ -257,7 +257,7 @@ cdef class Component(Picklable):
         Method that reset the optical surfaces that compose the Component.
         For example the detector surfaces should be reset before repeating the
         ray trace to erase the hit lists. Normally this method should not be
-        used directly. It is called when the reset method of the sistem class is
+        used directly. It is called when the reset method of the system class is
         called
         """
         for comp in self.surflist:
@@ -273,7 +273,7 @@ cdef class Component(Picklable):
         """
         # Determine the refraction index of the incident and the refracted media
         # If ri.n is equal to the component refraction index, the ray is coming out
-        # from the componnent, if not, it is goint in to the component.
+        # from the component, if not, it is goint in to the component.
 
         my_n = self.n(ri.wavelength)
 

--- a/pyoptools/raytrace/mat_lib/data/inorganic/Si/Chandler-Horowitz.yml
+++ b/pyoptools/raytrace/mat_lib/data/inorganic/Si/Chandler-Horowitz.yml
@@ -3,7 +3,7 @@
 # copyright and related rights waived via CC0 1.0
 
 REFERENCES: "D. Chandler-Horowitz and P. M. Amirtharaj. High-accuracy, midinfrared (450 cm<sup>−1</sup> ≤ ω ≤ 4000 cm<sup>−1</sup>) refractive index values of silicon, <a href=\"https://doi.org/10.1063/1.1923612\"><i>J. Appl. Phys.</i> <b>97</b>, 123526 (2005)</a>"
-COMMENTS: "Room temperatue."
+COMMENTS: "Room temperature."
 DATA:
   - type: formula 4
     wavelength_range: 2.5 22.222

--- a/pyoptools/raytrace/mat_lib/data/inorganic/Sn/Golovashkin-4.2K.yml
+++ b/pyoptools/raytrace/mat_lib/data/inorganic/Sn/Golovashkin-4.2K.yml
@@ -2,7 +2,7 @@
 # refractiveindex.info database is in the public domain
 # copyright and related rights waived via CC0 1.0
 
-REFERENCES: "A. I. Golovashkin and G. P. Motulevich. Optical properties of tin at helium temperaturs, <a href=\"http://jetp.ac.ru/cgi-bin/e/index/e/20/1/p44?a=list\"><i>Sov. Phys. JETP</i> <b>20</b>, 44-49 (1965)</a>"
+REFERENCES: "A. I. Golovashkin and G. P. Motulevich. Optical properties of tin at helium temperatures, <a href=\"http://jetp.ac.ru/cgi-bin/e/index/e/20/1/p44?a=list\"><i>Sov. Phys. JETP</i> <b>20</b>, 44-49 (1965)</a>"
 COMMENTS: "4.2 K (-268.95 °C)"
 DATA:
   - type: tabulated nk

--- a/pyoptools/raytrace/mat_lib/data/inorganic/Sn/Golovashkin-78K.yml
+++ b/pyoptools/raytrace/mat_lib/data/inorganic/Sn/Golovashkin-78K.yml
@@ -2,7 +2,7 @@
 # refractiveindex.info database is in the public domain
 # copyright and related rights waived via CC0 1.0
 
-REFERENCES: "1) A. I. Golovashkin and G. P. Motulevich. Optical and electrical properties of tin, <a href=\"http://jetp.ac.ru/cgi-bin/e/index/e/19/2/p310?a=list\"><i>Sov. Phys. JETP</i> <b>19</b>, 310-317 (1964)</a><br>2) A. I. Golovashkin and G. P. Motulevich. Optical properties of tin at helium temperaturs, <a href=\"http://jetp.ac.ru/cgi-bin/e/index/e/20/1/p44?a=list\"><i>Sov. Phys. JETP</i> <b>20</b>, 44-49 (1965)</a>"
+REFERENCES: "1) A. I. Golovashkin and G. P. Motulevich. Optical and electrical properties of tin, <a href=\"http://jetp.ac.ru/cgi-bin/e/index/e/19/2/p310?a=list\"><i>Sov. Phys. JETP</i> <b>19</b>, 310-317 (1964)</a><br>2) A. I. Golovashkin and G. P. Motulevich. Optical properties of tin at helium temperatures, <a href=\"http://jetp.ac.ru/cgi-bin/e/index/e/20/1/p44?a=list\"><i>Sov. Phys. JETP</i> <b>20</b>, 44-49 (1965)</a>"
 COMMENTS: "78 K (-195.15 °C)"
 DATA:
   - type: tabulated nk

--- a/pyoptools/raytrace/mat_lib/material.py
+++ b/pyoptools/raytrace/mat_lib/material.py
@@ -208,7 +208,7 @@ class MaterialLibrary:
         """
 
         if self.prefix is not None:
-            raise Exception('get_from only availabe on base library.')
+            raise Exception('get_from only available on base library.')
 
         for libname in libs.split(' '):
             libname = libname.lower()


### PR DESCRIPTION
Found via `codespell -q3 -L childs,clen,commun,componentes,fo,fof,mater,nd,ony,preforms,querry,ser,utiliza`