### PR TITLE
Freecad pyoptools fix

### DIFF
--- a/Tutorial/Untitled.ipynb
+++ b/Tutorial/Untitled.ipynb
@@ -1,0 +1,90 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "concerned-probability",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pythreejs import *\n",
+    "from IPython.display import display\n",
+    "from math import pi\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "refined-insurance",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reduce repo churn for examples with embedded state:\n",
+    "from pythreejs._example_helper import use_example_model_ids\n",
+    "use_example_model_ids()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "appreciated-gregory",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "pythree_example_model_002",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "BoxGeometry(depth=15.0, depthSegments=15, height=10.0, heightSegments=10, width=5.0, widthSegments=5)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "BoxGeometry(\n",
+    "    width=5,\n",
+    "    height=10,\n",
+    "    depth=15,\n",
+    "    widthSegments=5,\n",
+    "    heightSegments=10,\n",
+    "    depthSegments=15)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "neither-lightweight",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyoptools/raytrace/library/library.py
+++ b/pyoptools/raytrace/library/library.py
@@ -122,6 +122,9 @@ class LibraryModule:
     def _json_files(self):
         return list(self.dp.glob("*.json")) + self._user_libraries
 
+    def catalogs(self):
+        return [catalog.stem for catalog in self._json_files()]
+
 
 sys.modules[__name__] = LibraryModule()
 
@@ -129,7 +132,7 @@ sys.modules[__name__] = LibraryModule()
 class OpticCatalog:
     def __init__(self, catalog_path):
         self.catalog_path = catalog_path
-        self.jf = catalog_path.open(mode="r+b")
+        self.jf = catalog_path.open(mode="rb")
 
     def items(self):
         gen = ijson.kvitems(self.jf, "", use_float=True)

--- a/pyoptools/raytrace/mat_lib/material.py
+++ b/pyoptools/raytrace/mat_lib/material.py
@@ -246,6 +246,23 @@ class MaterialLibrary:
         else:
             raise AttributeError(f"Material {name} not found.")
 
+    def get_glass_libraries(self):
+        """Returns a list of strings containing the names of the glass 
+        libraries defined in PyOpTools"""
+        
+        libpaths = list(self.glass_path.glob("*"))
+
+        return [lib_path.parts[-1] for lib_path in libpaths]
+
+    def get_glass_materials_from_library(self,libname):
+        """Returns a list of strings containing the names of the materials 
+           defined in the library 'libname'
+        """
+        matpaths = list(self.glass_path.glob(f"{libname}/*.yml"))
+        matfiles= [mat_path.parts[-1] for mat_path in matpaths]
+        return [mat.split(".")[0] for mat in matfiles]
+        
+
 class CompoundLibrary:
     def __init__(self, lib_path):
         self.lib_path = lib_path

--- a/pyoptools/raytrace/mat_lib/material.py
+++ b/pyoptools/raytrace/mat_lib/material.py
@@ -252,15 +252,18 @@ class MaterialLibrary:
         
         libpaths = list(self.glass_path.glob("*"))
 
-        return [lib_path.parts[-1] for lib_path in libpaths]
+        return ["aliases"]+[lib_path.parts[-1] for lib_path in libpaths]
 
     def get_glass_materials_from_library(self,libname):
         """Returns a list of strings containing the names of the materials 
            defined in the library 'libname'
         """
-        matpaths = list(self.glass_path.glob(f"{libname}/*.yml"))
-        matfiles= [mat_path.parts[-1] for mat_path in matpaths]
-        return [mat.split(".")[0] for mat in matfiles]
+        
+        if libname == "aliases":
+            return list(self.aliases.keys())
+        
+        matfiles = self.glass_path.glob(f"{libname}/*.yml")
+        return [mat.stem for mat in matfiles]
         
 
 class CompoundLibrary:

--- a/pyoptools/raytrace/mat_lib/material.py
+++ b/pyoptools/raytrace/mat_lib/material.py
@@ -125,12 +125,18 @@ class MaterialLibrary:
         else:
             raise KeyError(f"Material {name} not found.")
 
-    def find_material(self, search, printout=True):
+    def find_material(self, search, printout=True, exact=False, unalias=False):
         """Search for a material where the string _search_ is found in the
         name or description. For example:
 
         If printout is True, prints a list of the commands used to access
         the matching materials.
+
+        If exact is True, return only the items where the material name is an
+        exact match of the search string.
+
+        If unalias is True, the materials found in the alises list, will be 
+        translated to the real material.
 
         Returns a list of the keys which can be used to retrieve candidate
         materials.
@@ -174,6 +180,23 @@ class MaterialLibrary:
             if r is not None:
                 results += r
 
+        if exact:
+            results = list(filter(lambda mat_item: mat_item[1]==search,
+                                  results))
+        if unalias:
+            unaliased = []
+            for r in results:
+                if r[0] is None:
+                    realmat = self.aliases[r[1]]
+
+                    if realmat["type"] != "glass":
+                        raise ValueError("Don't know how to handle {}".format(realmat["type"]))
+                    
+                    unaliased.append((realmat["library"], realmat["material"],None))
+                else:
+                    unaliased.append(r)
+            results = unaliased
+            
         if printout:
             for r in results:
                 catalog, name, ref = r

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setup(
             "data/glass/*/*/*",
             "data/inorganic/*",
             "data/inorganic/*/*",
+            "data/organic/*",
+            "data/organic/*/*",
             "data/aliases.json",
         ],
         "pyoptools.raytrace.library": [


### PR DESCRIPTION
The new Component and Material infraestructure made pyoptools incompatible with FreeCAD pyoptools. To fix this, it was needed to add a couple methods to find the materials and the libraries. Also there was a two small bug when creating a deb file that were fixed.