### PR TITLE
Bug fix : optic_factory not applying material if no material argument in the Componet class

### DIFF
--- a/pyoptools/raytrace/_comp_lib/optic_factory.py
+++ b/pyoptools/raytrace/_comp_lib/optic_factory.py
@@ -31,12 +31,13 @@ def optic_factory(**kwargs):
                 m = material.get_from(v, kwargs['glass_catalogs'])
             else:
                 m = material[v]
-
             kwargs[k] = m
 
-    # Include only elements with corresponding key in constructor
+    # Include only elements with corresponding key in constructor,
+    # or 'material' (since it is defined in the base class)
     sig = signature(klass)
-    new_kwargs = {k:v for (k,v) in kwargs.items() if k in sig.parameters}
+    valid_keys = list(sig.parameters.keys()) + ['material']
+    new_kwargs = {k:v for (k,v) in kwargs.items() if k in valid_keys}
 
     return klass(**new_kwargs)
 


### PR DESCRIPTION
[this was in aspheres_library PR, moved to separate PR since not related.]

 * Bug fix : fixed material type not being applied to Component instances by optic_factory when the material is not explicitly required by the constructor (this had affected SphericalLens instances loaded from the component library).

I think strictly the better design would be to not have the _material_ argument in _Component_ constructor and then fix SphericalLens (and any others) to explicitly take the material keyword argument. After all, not all possible components have a relevant material (e.g. optic stops).

I wasn't sure if that would have some other consequences so just fixed it this way for now.