### PR TITLE
Upload artifacts to PyPI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build Package
 on: push
 
 jobs:
-  build-wheels:
+  build:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -18,10 +18,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel twine
-        pip install Cython==0.29.30 --install-option="--no-cython-compile"
+        pip install Cython==0.29.30
         pip install numpy==1.21.6 cibuildwheel
     - name: Build sdist
-      run: python setup.py sdist --formats=gztar,zip
+      run: python setup.py sdist --formats=zip
     - name: Build wheels
       run: |
         python -m cibuildwheel --output-dir dist/
@@ -37,3 +37,14 @@ jobs:
           dist/*.tar.gz
           dist/*.zip
         retention-days: 7
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    steps:
+      - uses: actions/download-artifact@v2
+      - name: Publish distribution
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -8,6 +8,14 @@ pyOpTools can be downloaded from the project GitHub repository at:
 
     https://github.com/cihologramas/pyoptools
 
+Installing via pip
+------------------
+
+On Windows, Mac OS and Linux you can use `pip`` to install pyOpTools.
+
+    pip install pyoptools
+
+This will install the latest available version of pyoptools.
 
 Installing it in Debian 11 (should work on any Debian derivative)
 -----------------------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
-description-file = README.md
+long_description = file: README.md
+long_description_content_type = text/markdown


### PR DESCRIPTION
This pull requests uploads the already build packages for windows, linux and mac os to PyPI, so it will be possible to install PyOpTools simply by `pip install pyoptools`.

What needs to be done by pyoptools maintainers:
* Generate an API token at PyPI (https://pypi.org/help/#apitoken)
* Create a repository secret named "PYPI_API_TOKEN" with the retrieved API token as value (https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)
* As the current available version is 0.1.1 on PyPI you should update the version info in `setup.py` (maybe 0.2.0?)
* Every tagged version will be uploaded to PyPI. Create a tag via Github named like the version (e.g. "0.2.0")

Next steps (future pull requests):
* get the version information automatically based on the tag name
* cleanup project files to use a `pyproject.toml` based approach - everything is cleaner and easier