### PR TITLE
Enable DeprecationWarnings in Jupyter

### DIFF
--- a/pyoptools/all.py
+++ b/pyoptools/all.py
@@ -30,6 +30,10 @@
 #   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# Enable warnings in Jupyter
+import warnings
+warnings.filterwarnings('always', category=DeprecationWarning)
+
 """
 Package containing modules and submodules defining an *API* for optical
 raytracing and wave propagation calculations.

--- a/pyoptools/raytrace/_comp_lib/cube.py
+++ b/pyoptools/raytrace/_comp_lib/cube.py
@@ -143,7 +143,6 @@ class BeamSplitingCube(BeamSplittingCube):
     .. warning:: Will be removed in the future"""
 
     def __init__(self, *argv, **kwargs):
-        warnings.simplefilter("default")
 
         warnings.warn(
             "This class will be deprecated (the spelling is not "

--- a/pyoptools/raytrace/library/library.py
+++ b/pyoptools/raytrace/library/library.py
@@ -86,7 +86,6 @@ class LibraryModule:
         """Deprecated method. Simply use dictionary style access to get
         an optic given the part number.
         """
-        warnings.simplefilter("default")
         warnings.warn(
             "This method is deprecated, you can use dictionary-style access " "instead",
             DeprecationWarning,
@@ -150,7 +149,6 @@ class OpticCatalog:
         return optic_factory(**self.descriptor(part))
 
     def get(self, part):
-        warnings.simplefilter("default")
         warnings.warn(
             "This method is deprecated, you can use dictionary-style access instead",
             DeprecationWarning,

--- a/pyoptools/raytrace/ray/ray.pyx
+++ b/pyoptools/raytrace/ray/ray.pyx
@@ -20,7 +20,6 @@ cdef extern from "math.h":
     double sqrt(double)
 
 import warnings
-warnings.simplefilter("always")
 
 
 from pyoptools.misc.cmisc.eigen cimport Vector3d, Matrix3d, convert_vector3d_to_tuple, \


### PR DESCRIPTION
This commit ensures that all DeprecationWarnings are enabled when running Jupyter, allowing for better tracking of deprecated features. The change does not impact FreeCAD functionality.