### PR TITLE
Fixes for #183 #184 #185

### DIFF
--- a/pyoptools/raytrace/surface/cylindrical.pyx
+++ b/pyoptools/raytrace/surface/cylindrical.pyx
@@ -222,6 +222,5 @@ cdef class Cylindrical(Surface):
             f"Cylindrical(shape={repr(self.shape)}, "
             f"reflectivity={self.reflectivity}, "
             f"curvature={self.curvature}, "
-            f"aperture_shape={repr(self.ap_shape)}, "
             f"id={self.id})"
         )

--- a/pyoptools/raytrace/surface/spherical.pyx
+++ b/pyoptools/raytrace/surface/spherical.pyx
@@ -207,6 +207,5 @@ cdef class Spherical(Surface):
             f"Spherical(shape={repr(self.shape)}, "
             f"reflectivity={self.reflectivity}, "
             f"curvature={self.curvature}, "
-            f"aperture_shape={repr(self.ap_shape)}, "
             f"id={self.id})"
         )

--- a/pyoptools/raytrace/surface/spherical.pyx
+++ b/pyoptools/raytrace/surface/spherical.pyx
@@ -96,7 +96,7 @@ cdef class Spherical(Surface):
         - This method uses the quadratic formula to find the intersection points
         and selects the valid one based on the direction of propagation.
         - There may be issues if the ray propagates along the X or Y direction
-        (i.e., if the ray is perpendicularto the Z-axis). This can lead
+        (i.e., if the ray is perpendicular to the Z-axis). This can lead
         to numerical instability, and a better solution may be required.
 
         """

--- a/pyoptools/raytrace/surface/surface.pyx
+++ b/pyoptools/raytrace/surface/surface.pyx
@@ -343,46 +343,59 @@ cdef class Surface(Picklable):
 
         This method calculates the intersection point of the given incident ray
         with the surface and stores the result in the provided
-        `intersection_point` vector. It also checks whether the ray intersects
-        within the defined boundary of the surface.
-        If the intersection occurs outside the surface's boundary, the method
-        sets `intersection_point_ptr` to a NaN `Vector3d`.
+        `intersection_point` vector. It performs multiple validation checks:
+        1. Whether the ray intersects within the defined boundary of the surface
+        2. Whether the intersection occurs in front of the ray origin (forward
+           propagation)
 
+        If any validation fails, the method sets `intersection_point` to a vector
+        of NaN values.
         Parameters
         ----------
         incident_ray : Ray
             The incident ray that intersects with the surface.
-        intersection_point : Vector3d
-            A eigen::Vector3d instance where the intersection point will be
-            stored. If the intersection is outside the surface boundary, this
-            will be set to a (NaN, NaN, NaN) vector.
-
+        intersection_point : Vector3d&
+            Reference to an eigen::Vector3d instance where the intersection point will
+            be stored. If the intersection is invalid, this will be set to
+            (NaN, NaN, NaN).
         Notes
         -----
-        - This method performs a check to ensure that the intersection occurs
-        within the defined boundary of the surface. If the intersection is
-        outside this boundary, it sets the intersection point to a
-        (NaN, NaN, NaN) vector.
-        - It is a Cython-specific, low-level function intended for internal
-        use.
-        - This method should be called by other Cython code that requires
-        direct access to the intersection calculation without Python object
-        overhead.
+        - This is a Cython-specific, low-level function intended for internal use.
+        - The method doesn't return a value; instead, it modifies the passed
+          `intersection_point`.
+        - Forward propagation is enforced by ensuring the intersection occurs in the
+          direction of the ray (positive distance).
         """
-        # Get ray intersection
+        # Calculate the intersection point between ray and surface
         self._calculate_intersection(incident_ray, intersection_point)
 
-        # Check if the intersection point is inside the shape
-        if not(self.shape.hit_cy(intersection_point)):
+        # Validation 1: Check if the intersection point is inside the surface boundary
+        if not self.shape.hit_cy(intersection_point):
+            return
+
+        # Validation 2: Check if the intersection is in front of the ray
+        # (forward propagation)
+        # Calculate distance along ray direction from origin to intersection
+        cdef double dist = (intersection_point -
+                            incident_ray._origin).dot(incident_ray._direction)
+
+        # If distance is negative or too small (numerical precision threshold),
+        # the intersection is invalid
+        if dist < 1.e-10:
             assign_nan_to_vector3d(intersection_point)
 
     def intersection(self, Ray incident_ray):
         """
-        Calculate the point of intersection between a ray and a surface.
+        Calculate the point of intersection between a ray and this surface.
 
         This method returns the point of intersection between the surface and
         the incident ray. The intersection point is calculated in the
         coordinate system of the surface.
+
+        This calculation is performed considering only the ray and this surface
+        in isolation. It does not take into account any other optical elements
+        that may be present in the system. For this method, the only existing
+        elements are the ray and the surface.
 
         If there is no point of intersection, such as when the ray is outside
         the surface's boundary, the method returns a tuple (NaN, NaN, NaN).
@@ -413,7 +426,7 @@ cdef class Surface(Picklable):
 
         This method computes the distance from the origin of the given incident
         ray to the intersection point on the surface. It calculates the
-        intersection point and stores it in `intersection_point_ptr`. If there
+        intersection point and stores it in `intersection_point`. If there
         is no valid intersection, the method sets the intersection point to
         NaN and returns infinity for the distance.
 
@@ -438,34 +451,31 @@ cdef class Surface(Picklable):
         due to rounding errors, the distance is considered infinite.
         - The method handles cases where the surface is ahead of or behind the
         ray, or when there is no valid intersection.
+        - Distances greater than 1e10 are considered as infinity to avoid
+        numerical precision issues with extremely distant intersections.
         """
+        # Calculate the intersection point and store it in intersection_point
         self.intersection_cy(incident_ray, intersection_point)
 
         cdef double dist
-        # Dist is positive if the current surface is ahead of the ray.
-        # If the surface is behind the ray, Dist becomes negative
-        # If there is no intersection, Dist becomes inf
-        # any(isinf(PI)):
+
+        # Check if any component of the intersection point is NaN, indicating
+        # no intersection
         if  (isnan(intersection_point(0)) or
              isnan(intersection_point(1)) or
              isnan(intersection_point(2))):
-
             dist = INFINITY
         else:
-            # Dist = dot(PI-iray.pos, iray.dir)
+            # Calculate the distance as the dot product of the vector from ray origin
+            # to intersection point with the ray direction
             dist = (intersection_point - incident_ray._origin). \
                 dot(incident_ray._direction)
 
+        # Treat extremely large distances (>1e10) as infinity
+        # This helps avoid numerical precision issues with very distant intersections
         if dist > 1e10:
             dist = INFINITY
 
-        # Because of rounding errors, some times when the distance should be 0
-        # It gives a very small number. A distance is too small, or 0 means
-        # that the ray was already refracted by the surface, and the surface
-        # is already behind the ray.
-
-        if dist < 1.e-10:
-            dist = INFINITY
         return dist
 
     def distance(self, incident_ray):

--- a/pyoptools/raytrace/surface/surface.pyx
+++ b/pyoptools/raytrace/surface/surface.pyx
@@ -371,6 +371,7 @@ cdef class Surface(Picklable):
 
         # Validation 1: Check if the intersection point is inside the surface boundary
         if not self.shape.hit_cy(intersection_point):
+            assign_nan_to_vector3d(intersection_point)
             return
 
         # Validation 2: Check if the intersection is in front of the ray

--- a/pyoptools/raytrace/surface/surface.pyx
+++ b/pyoptools/raytrace/surface/surface.pyx
@@ -85,7 +85,6 @@ cdef class Surface(Picklable):
 
         self.id = []
 
-
         if filter_spec is None:
             filter_spec = ("nofilter",)
 

--- a/pyoptools/raytrace/system/system.pxd
+++ b/pyoptools/raytrace/system/system.pxd
@@ -7,7 +7,7 @@ cdef class System(Picklable):
     cdef public double n  # This could be changed to material
     cdef public list _np_rays
     cdef public list _p_rays
-    cdef public int _max_ray_parent_cnt
+    cdef public int _max_ray_parent
     cdef public float intensity_threshold
 
     cdef public int _exit_status_flag  # 0: no error, 1: error

--- a/pyoptools/raytrace/system/system.pyx
+++ b/pyoptools/raytrace/system/system.pyx
@@ -90,19 +90,19 @@ cdef class System(Picklable):
     """
 
     @property
-    def max_ray_parent_cnt(self):
-        if self._max_ray_parent_cnt > 0:
-            return self._max_ray_parent_cnt
+    def max_ray_parent(self):
+        if self._max_ray_parent > 0:
+            return self._max_ray_parent
         else:
             return None
 
-    @max_ray_parent_cnt.setter
-    def max_ray_parent_cnt(self, val):
+    @max_ray_parent.setter
+    def max_ray_parent(self, val):
 
         if val is None:
-            self._max_ray_parent_cnt = 0
+            self._max_ray_parent = 0
         else:
-            self._max_ray_parent_cnt = int(val)
+            self._max_ray_parent = int(val)
 
     @property
     def prop_ray(self):
@@ -118,7 +118,7 @@ cdef class System(Picklable):
     def complist(self, list):
         self._complist=plist(list)
 
-    def __init__(self, complist=None, n=1., max_ray_parent_cnt=None,
+    def __init__(self, complist=None, n=1., max_ray_parent=None,
                  intensity_threshold=0):
 
         # Look in the init os component to see why this in done this way
@@ -132,12 +132,12 @@ cdef class System(Picklable):
 
         # self.propagation_limit is integer, so if it is 0, then there is no limit
 
-        self.max_ray_parent_cnt = max_ray_parent_cnt
+        self.max_ray_parent = max_ray_parent
 
         self.intensity_threshold = intensity_threshold
 
         # Flag that indicates if a ray propagation was truncated or not by the
-        # intensity_threshold or the max_ray_parent_cnt condition
+        # intensity_threshold or the max_ray_parent condition
         # if 0 no truncation was done
 
         self._exit_status_flag = 0
@@ -149,12 +149,12 @@ cdef class System(Picklable):
 
             if isinstance(comp, System):
                 comp.n=self.n
-                comp.max_ray_parent_cnt = self.max_ray_parent_cnt
+                comp.max_ray_parent = self.max_ray_parent
                 comp.intensity_threshold = self.intensity_threshold
 
         # Add to the keys to the state key list
         Picklable.__init__(self, "complist", "n", "_np_rays", "_p_rays",
-                           "_max_ray_parent_cnt", "intensity_threshold")
+                           "_max_ray_parent", "intensity_threshold")
 
     # Dict type and list type interface to expose complist
 
@@ -550,8 +550,8 @@ cdef class System(Picklable):
                 # more than propagation_limit times
 
                 if i.intensity>self.intensity_threshold:
-                    if (self._max_ray_parent_cnt == 0 or
-                       i._parent_cnt<self.max_ray_parent_cnt):
+                    if (self._max_ray_parent == 0 or
+                       i._parent_cnt<self.max_ray_parent):
                         self.propagate_ray(i)
                     else:
                         self._exit_status_flag = 1

--- a/tests/raytrace/surface/test_surface_ray_intersection.py
+++ b/tests/raytrace/surface/test_surface_ray_intersection.py
@@ -1,0 +1,36 @@
+from math import isnan
+
+from pyoptools.raytrace.ray.ray import Ray
+from pyoptools.raytrace.shape.circular import Circular
+
+# local imports
+from pyoptools.raytrace.surface.spherical import Spherical
+
+
+def test_surface_ray_intersection_backpropagation():
+    """Test ray-surface intersection calculation with rays propagating in
+    different directions.
+
+    This test verifies two cases:
+    1. When a ray propagates in a direction that doesn't intersect the surface
+       (forward +z), the intersection point should contain NaN values.
+    2. When a ray propagates toward the surface (backward -z),
+       a valid intersection point should be calculated.
+    """
+    # Create a test spherical surface with 10mm radius of curvature and 10mm
+    # aperture
+    s = Spherical(curvature=1 / 10.0, shape=Circular(radius=10.0))
+
+    # Case 1: Ray pointing away from the surface (in +z direction)
+    r = Ray([0.0, 0.0, 10.0], [0.0, 0.0, 1.0])
+    intersection_point = s.intersection(r)
+
+    # Verify no intersection occurs (values should be NaN)
+    assert all(isnan(coord) for coord in intersection_point)
+
+    # Case 2: Ray pointing toward the surface (in -z direction)
+    r = Ray([0.0, 0.0, 10.0], [0.0, 0.0, -1.0])
+    intersection_point = s.intersection(r)
+
+    # Verify a valid intersection is found (no NaN values)
+    assert all(not isnan(coord) for coord in intersection_point)

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,40 @@
+from pyoptools.raytrace.surface.cylindrical import Cylindrical
+from pyoptools.raytrace.surface.spherical import Spherical
+
+
+def test_spherical_repr():
+    # Create a Spherical object with known parameters
+    curvature = 0.01
+    reflectivity = 0.5
+    aperture_shape = None  # Assuming no aperture shape for simplicity
+    spherical_surface = Spherical(
+        curvature=curvature, reflectivity=reflectivity, shape=aperture_shape
+    )
+    # Expected representation string
+    expected_repr = (
+        f"Spherical(shape={repr(spherical_surface.shape)}, "
+        f"reflectivity={reflectivity}, "
+        f"curvature={curvature}, "
+        f"id={spherical_surface.id})"
+    )
+    # Check if the actual representation matches the expected one
+    assert repr(spherical_surface) == expected_repr
+
+
+def test_cylindrical_repr():
+    # Create a Cylindrical object with known parameters
+    curvature = 0.01
+    reflectivity = 0.5
+    aperture_shape = None  # Assuming no aperture shape for simplicity
+    cylindrical_surface = Cylindrical(
+        curvature=curvature, reflectivity=reflectivity, shape=aperture_shape
+    )
+    # Expected representation string
+    expected_repr = (
+        f"Cylindrical(shape={repr(cylindrical_surface.shape)}, "
+        f"reflectivity={reflectivity}, "
+        f"curvature={curvature}, "
+        f"id={cylindrical_surface.id})"
+    )
+    # Check if the actual representation matches the expected one
+    assert repr(cylindrical_surface) == expected_repr


### PR DESCRIPTION
Fix to #185: The inconsistency on max_ray_parent was fixed. The docstring name was chosen.
Fix to #184: The repr methods of Spherical, and Cylindrical was fixed. A test for those repr was added.
Fix to #183: The inconsistency on Surface.distance(ray) and Surface.intersection(ray) was fixed.