### PR TITLE
Fix typo in error message for missing pythreejs

### DIFF
--- a/pyoptools/gui/ipywidgets.py
+++ b/pyoptools/gui/ipywidgets.py
@@ -13,7 +13,7 @@ from numpy import array
 try:
     import pythreejs as py3js
 except ModuleNotFoundError:
-    print("need py3js installed to be able to plot systems in Jupyter notebooks")
+    print("need pythreejs installed to be able to plot systems in Jupyter notebooks")
 
 from numpy import pi, array, dot, sin, cos
 from math import sqrt


### PR DESCRIPTION
Note that users may confuse py3js with pythreejs; however, the library required for this project is pythreejs.