### PR TITLE
Refactor optical stop and add SimpleDMD surface

### DIFF
--- a/pyoptools/__init__.py
+++ b/pyoptools/__init__.py
@@ -32,3 +32,15 @@
 Package containing modules and submodules defining an *API* for optical
 raytracing and wave propagation calculations.
 """
+
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    # Python < 3.8
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("pyoptools")
+except PackageNotFoundError:
+    # Package is not installed
+    __version__ = "unknown"

--- a/pyoptools/raytrace/_comp_lib/aspheric_lens.py
+++ b/pyoptools/raytrace/_comp_lib/aspheric_lens.py
@@ -5,7 +5,7 @@ Definition of a radially-symmetric aspheric lens.
 from math import pi
 
 from pyoptools.raytrace.component import Component
-from pyoptools.raytrace.surface import Aspherical, Cylinder, Plane, Aperture
+from pyoptools.raytrace.surface import Aspherical, Cylinder, Plane, OpticalStop
 from pyoptools.raytrace.shape import Circular
 from pyoptools.misc.function_2d.poly_r.poly_r import PolyR
 
@@ -89,7 +89,7 @@ class AsphericLens(Component):
         },
         s2=None,
         *args,
-        **kwargs
+        **kwargs,
     ):
         Component.__init__(self, *args, **kwargs)
 
@@ -147,7 +147,9 @@ class AsphericLens(Component):
                 poly=PolyR(s2_defn.polycoefficents),
             )
             if s2_defn.max_thickness is None:
-                s2_defn.max_thickness = s2_surf.get_z_at_point(s2_defn.diameter / 2.0, 0)
+                s2_defn.max_thickness = s2_surf.get_z_at_point(
+                    s2_defn.diameter / 2.0, 0
+                )
             side_thickness -= s2_defn.max_thickness
         self.surflist.append((s2_surf, (0, 0, thickness), (0, pi, pi / 2)))
 
@@ -182,7 +184,7 @@ class AsphericLens(Component):
         """
 
         if self.outer_diameter > defn.diameter:
-            brim = Aperture(
+            brim = OpticalStop(
                 shape=Circular(radius=0.5 * self.outer_diameter),
                 ap_shape=Circular(radius=0.5 * defn.diameter),
             )

--- a/pyoptools/raytrace/_comp_lib/ideallens.py
+++ b/pyoptools/raytrace/_comp_lib/ideallens.py
@@ -1,15 +1,13 @@
-
 """
 Modulo con clases y funciones auxiliares.
 """
-
 
 from pyoptools.raytrace.surface.idealsurface import IdealSurface
 from pyoptools.raytrace.surface.idealpplanes import IdealPPlanes
 
 from pyoptools.raytrace.shape import Rectangular
 from pyoptools.raytrace.component import Component
-from pyoptools.raytrace.surface.aperture import Aperture
+from pyoptools.raytrace.surface.opticalstop import OpticalStop
 from pyoptools.raytrace.system.system import System
 
 
@@ -29,8 +27,8 @@ def IdealTLens(
 ):
     """Function to define an ideal thick lens."""
     S1 = IdealPPlanes(shape=shape, f=f, d=d)
-    S2 = Aperture(shape=Rectangular(size=(50, 50)), ap_shape=ap_shape)
-    S3 = Aperture(shape=Rectangular(size=(50, 50)), ap_shape=ap_shape)
+    S2 = OpticalStop(shape=Rectangular(size=(50, 50)), ap_shape=ap_shape)
+    S3 = OpticalStop(shape=Rectangular(size=(50, 50)), ap_shape=ap_shape)
     A1 = Component(
         surflist=[
             (S2, (0, 0, 0), (0, 0, 0)),

--- a/pyoptools/raytrace/_comp_lib/simple_dmd_device.py
+++ b/pyoptools/raytrace/_comp_lib/simple_dmd_device.py
@@ -1,0 +1,244 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2007, Ricardo Amézquita Orozco
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the GPLv3
+# license included in LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.
+#
+#
+# Author:          Ricardo Amézquita Orozco
+# Description:     SimpleDMD Device component module
+# Symbols Defined: SimpleDMDDevice
+# ------------------------------------------------------------------------------
+
+"""
+Definition of SimpleDMD device component.
+
+This module provides a complete DMD (Digital Micromirror Device) component
+with a parallelepiped structure consisting of a SimpleDMD surface as the front
+face and OpticalStop surfaces on the other five faces.
+"""
+
+from math import pi, radians
+
+from pyoptools.raytrace.component import Component
+from pyoptools.raytrace.surface import SimpleDMD, OpticalStop
+from pyoptools.raytrace.shape import Rectangular
+
+
+class SimpleDMDDevice(Component):
+    """Component representing a complete DMD device with parallelepiped structure.
+
+    SimpleDMDDevice provides a convenient wrapper for integrating DMD (Digital
+    Micromirror Device) elements into optical systems. The component consists of
+    6 surfaces arranged as a parallelepiped:
+    - Front face: SimpleDMD surface (active DMD with state-dependent reflection)
+    - Other 5 faces: OpticalStop surfaces (full stops with no apertures)
+
+    **Origin Pattern**: This component follows the "principal surface" pattern
+    where the origin is placed at the center of the optically active surface
+    (the DMD front face at z=0). This is consistent with mirrors and diffraction
+    gratings, but differs from lenses which use the geometric center pattern.
+
+    Parameters
+    ----------
+    tilt_angle : float
+        Tilt angle in radians for the SimpleDMD surface. This is the angle between
+        the surface normal and the perpendicular direction (Z-axis). When tilt_angle=0,
+        the normal is perpendicular to the surface. Use math.radians() to convert
+        from degrees.
+    on_direction_angle : float
+        Direction angle in radians defining where the surface normal is rotated
+        to for the ON state. Measured counter-clockwise from the +X axis in the
+        XY plane when viewed from +Z. For example, 0° points toward +X, 90° points
+        toward +Y, 180° points toward -X, and 270° points toward -Y.
+    off_direction_angle : float
+        Direction angle in radians defining where the surface normal is rotated
+        to for the OFF state. Measured counter-clockwise from the +X axis in the
+        XY plane when viewed from +Z. For example, 0° points toward +X, 90° points
+        toward +Y, 180° points toward -X, and 270° points toward -Y.
+    state : str, optional
+        Initial DMD state: "on", "off", or "flat". Default is "flat".
+    width : float, optional
+        Width of the DMD device in mm (X dimension). Default is 10.8 mm,
+        matching typical Texas Instruments DLP chip active areas.
+    height : float, optional
+        Height of the DMD device in mm (Y dimension). Default is 10.8 mm.
+    thickness : float, optional
+        Thickness of the DMD device in mm (Z dimension). Default is 2.0 mm.
+    **kwargs
+        Additional arguments passed to Component base class.
+
+    Attributes
+    ----------
+    surflist : dict
+        Dictionary mapping surface names to (surface, position, rotation) tuples.
+        Keys are: "front", "back", "left", "right", "top", "bottom".
+
+    Examples
+    --------
+    Create a DMD device with 12° tilt magnitude::
+
+        from math import radians
+        from pyoptools.all import SimpleDMDDevice
+
+        dmd = SimpleDMDDevice(
+            tilt_angle=radians(12),           # 12° tilt magnitude
+            on_direction_angle=radians(45),   # Normal tilts toward northeast
+            off_direction_angle=radians(225), # Normal tilts toward southwest
+            state="on"
+        )
+
+    Create a DMD with custom dimensions::
+
+        dmd = SimpleDMDDevice(
+            tilt_angle=radians(12),
+            on_direction_angle=radians(45),
+            off_direction_angle=radians(225),
+            width=15.0,   # Custom width
+            height=12.0,  # Custom height
+            thickness=3.0 # Custom thickness
+        )
+
+    Change DMD state at runtime::
+
+        # Access the SimpleDMD surface and change state
+        dmd.surflist["front"][0].state = "off"
+
+    Notes
+    -----
+    - **Default dimensions**: 10.368×5.832×1.0 mm (DLP4710 active area dimensions)
+    - **Origin at DMD surface**: z=0 is at the center of the front (DMD) face,
+      following the "principal surface" pattern used by mirrors/gratings
+    - **SimpleDMD model**: Uses the simplified DMD surface model suitable for
+      system-level design. Does not model individual pixels or diffraction effects.
+    - **Side faces**: All five non-front faces are full stops (OpticalStop with
+      ap_shape=None) that block rays completely.
+    - **Direction angles**: These specify where the surface normal is rotated to,
+      which may differ from manufacturer datasheets. Adjust empirically to match
+      your desired optical behavior.
+
+    See Also
+    --------
+    SimpleDMD : The underlying DMD surface class
+    Component : Base class for optical components
+    OpticalStop : Stop surface used for the side faces
+    """
+
+    def __init__(
+        self,
+        tilt_angle,
+        on_direction_angle,
+        off_direction_angle,
+        state="flat",
+        width=10.368,
+        height=5.832,
+        thickness=2.0,
+        **kwargs,
+    ):
+        """Initialize SimpleDMDDevice component.
+
+        Parameters described in class docstring.
+        """
+        Component.__init__(self, **kwargs)
+
+        # Validate dimensions
+        if width <= 0:
+            raise ValueError(
+                f"Width must be positive, got {width}. Specify width in millimeters."
+            )
+        if height <= 0:
+            raise ValueError(
+                f"Height must be positive, got {height}. Specify height in millimeters."
+            )
+        if thickness <= 0:
+            raise ValueError(
+                f"Thickness must be positive, got {thickness}. "
+                "Specify thickness in millimeters."
+            )
+
+        # Store dimensions for __repr__
+        self._width = width
+        self._height = height
+        self._thickness = thickness
+        self._tilt_angle = tilt_angle
+        self._on_direction_angle = on_direction_angle
+        self._off_direction_angle = off_direction_angle
+        self._state = state
+
+        # Create front face - SimpleDMD surface at z=0 (origin at DMD surface)
+        front_surface = SimpleDMD(
+            tilt_angle=tilt_angle,
+            on_direction_angle=on_direction_angle,
+            off_direction_angle=off_direction_angle,
+            state=state,
+            shape=Rectangular(size=(width, height)),
+        )
+        self.surflist["front"] = (front_surface, (0, 0, 0), (0, pi, 0))
+
+        # Create back face - OpticalStop at z=-thickness
+        back_surface = OpticalStop(
+            shape=Rectangular(size=(width, height)),
+            ap_shape=None,  # Full stop, no aperture
+        )
+        self.surflist["back"] = (back_surface, (0, 0, thickness), (0, 0, 0))
+
+        # Create left face - OpticalStop at x=-width/2
+        left_surface = OpticalStop(
+            shape=Rectangular(size=(thickness, height)), ap_shape=None
+        )
+        self.surflist["left"] = (
+            left_surface,
+            (-width / 2, 0, -thickness / 2),
+            (0, pi / 2, 0),
+        )
+
+        # Create right face - OpticalStop at x=width/2
+        right_surface = OpticalStop(
+            shape=Rectangular(size=(thickness, height)), ap_shape=None
+        )
+        self.surflist["right"] = (
+            right_surface,
+            (width / 2, 0, -thickness / 2),
+            (0, -pi / 2, 0),
+        )
+
+        # Create top face - OpticalStop at y=height/2
+        top_surface = OpticalStop(
+            shape=Rectangular(size=(width, thickness)), ap_shape=None
+        )
+        self.surflist["top"] = (
+            top_surface,
+            (0, height / 2, -thickness / 2),
+            (-pi / 2, 0, 0),
+        )
+
+        # Create bottom face - OpticalStop at y=-height/2
+        bottom_surface = OpticalStop(
+            shape=Rectangular(size=(width, thickness)), ap_shape=None
+        )
+        self.surflist["bottom"] = (
+            bottom_surface,
+            (0, -height / 2, -thickness / 2),
+            (pi / 2, 0, 0),
+        )
+
+    def __repr__(self):
+        """Return string representation of SimpleDMDDevice.
+
+        Returns
+        -------
+        str
+            String showing component class, dimensions, and DMD state.
+        """
+        return (
+            f"SimpleDMDDevice("
+            f"width={self._width}, "
+            f"height={self._height}, "
+            f"thickness={self._thickness}, "
+            f"state='{self._state}', "
+            f"tilt_angle={self._tilt_angle:.5f}, "
+            f"on_direction_angle={self._on_direction_angle:.5f}, "
+            f"off_direction_angle={self._off_direction_angle:.5f})"
+        )

--- a/pyoptools/raytrace/_comp_lib/stop.py
+++ b/pyoptools/raytrace/_comp_lib/stop.py
@@ -19,7 +19,7 @@ Definition of stop components
 from numpy import sqrt, pi, absolute
 
 from pyoptools.raytrace.component import Component
-from pyoptools.raytrace.surface import Aperture
+from pyoptools.raytrace.surface import OpticalStop
 from pyoptools.raytrace.shape import Shape
 
 
@@ -60,7 +60,7 @@ class Stop(Component):
         Component.__init__(self, **traits)
         # self.shape=shape
         # self.ap_shape=ap_shape
-        face = Aperture(shape=shape, ap_shape=ap_shape)
+        face = OpticalStop(shape=shape, ap_shape=ap_shape)
         self.surflist["S1"] = (face, (0, 0, 0), (0, 0, 0))
 
     # ~ def __reduce__(self):

--- a/pyoptools/raytrace/comp_lib.py
+++ b/pyoptools/raytrace/comp_lib.py
@@ -29,6 +29,7 @@ __all__ = sorted(
         "RectMirror",
         "RectGratting",
         "PowellLens",
+        "SimpleDMDDevice",
     ]
 )
 
@@ -44,3 +45,4 @@ from ._comp_lib.ideallens import IdealLens, IdealTLens
 from ._comp_lib.mirror import RoundMirror, RectMirror
 from ._comp_lib.diffraction import RectGratting
 from ._comp_lib.powell_lens import PowellLens
+from ._comp_lib.simple_dmd_device import SimpleDMDDevice

--- a/pyoptools/raytrace/surface/__init__.py
+++ b/pyoptools/raytrace/surface/__init__.py
@@ -1,13 +1,11 @@
-
-"""Module that defines all the classes that describe the optical surfaces
-"""
+"""Module that defines all the classes that describe the optical surfaces"""
 
 from .surface import Surface
 from .cylindrical import Cylindrical
 from .plane import Plane
 from .spherical import Spherical
 from .detector import ArrayDetector
-from .aperture import Aperture
+from .opticalstop import OpticalStop, Aperture
 from .taylor_poly import TaylorPoly
 from .cylinder import Cylinder
 from .aspherical import Aspherical
@@ -15,6 +13,7 @@ from .powell import Powell
 from .plane_mask import RPPMask
 from .idealsurface import IdealSurface
 from .idealpplanes import IdealPPlanes
+from .simpledmd import SimpleDMD
 
 __all__ = [
     "Surface",
@@ -22,6 +21,7 @@ __all__ = [
     "Plane",
     "Spherical",
     "ArrayDetector",
+    "OpticalStop",
     "Aperture",
     "TaylorPoly",
     "Cylinder",
@@ -30,4 +30,5 @@ __all__ = [
     "RPPMask",
     "IdealSurface",
     "IdealPPlanes",
+    "SimpleDMD",
 ]

--- a/pyoptools/raytrace/surface/opticalstop.pyx
+++ b/pyoptools/raytrace/surface/opticalstop.pyx
@@ -1,0 +1,226 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2007, Ricardo Amézquita Orozco
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the GPLv3
+# license included in LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.
+#
+#
+# Author:          Ricardo Amézquita Orozco
+# Description:     Optical stops definition module
+# Symbols Defined: OpticalStop, Aperture (deprecated)
+# ------------------------------------------------------------------------------
+
+from pyoptools.raytrace.surface.plane cimport Plane
+
+from pyoptools.raytrace.shape.shape cimport Shape
+from pyoptools.raytrace.ray.ray cimport Ray
+
+from pyoptools.misc.cmisc.eigen cimport Vector3d, assign_nan_to_vector3d
+
+
+cdef class OpticalStop(Plane):
+    """
+    Class to define an optical stop surface.
+
+    The `OpticalStop` class is used to define stops in an optical system. It
+    represents a surface that has an external shape and an optional internal
+    aperture shape that defines a hole in the surface.
+
+    Parameters
+    ----------
+    shape : Shape, optional
+        An instance of a `Shape` subclass that defines the external shape
+        of the stop. This parameter is inherited from the `Plane` class
+        and passed through to it.
+    ap_shape : Shape, optional
+        An instance of a `Shape` subclass that defines the internal aperture
+        shape (the hole). If None, the stop has no internal aperture and acts
+        as a full stop, blocking rays outside the external shape boundary.
+
+    Examples
+    --------
+    Creating an optical stop with a rectangular external shape and
+    a circular aperture::
+
+        stop = OpticalStop(shape=Rectangular(size=(60, 60)),
+                           ap_shape=Circular(radius=2.5))
+
+    Creating a full stop with no internal aperture::
+
+        full_stop = OpticalStop(shape=Circular(radius=10), ap_shape=None)
+
+    Notes
+    -----
+    To create a stop component, it is recommended to use the `Stop` class
+    from the `comp_lib` module. The `Stop` class creates the optical stop surface
+    and encapsulates it in a component that can be used within a `System`.
+    """
+
+    cdef public Shape ap_shape
+
+    def __init__(self, ap_shape=None, *args, **kwargs):
+        Plane.__init__(self, *args, **kwargs)
+        self.ap_shape = ap_shape
+
+        # Add items to the state list
+        self.addkey("ap_shape")
+
+    cdef void _calculate_intersection(self,
+                                      Ray incident_ray,
+                                      Vector3d& intersection_point) noexcept nogil:
+        """
+        Calculate intersection point, blocking rays that hit the aperture.
+
+        If ap_shape is None (full stop), no additional blocking occurs beyond
+        the external shape boundary (handled by parent Surface class).
+        """
+
+        Plane._calculate_intersection(self,
+                                      incident_ray,
+                                      intersection_point)
+        # Only check aperture shape if it exists
+        if self.ap_shape is not None:
+            if self.ap_shape.hit_cy(intersection_point):
+                assign_nan_to_vector3d(intersection_point)
+
+    cpdef  list propagate(self, Ray ri, double ni, double nr):
+        # Calculate the intersection point and the surface normal
+        cdef Vector3d PI
+
+        self._calculate_intersection(ri, PI)
+
+        ret_ray = Ray.fast_init(PI,
+                                ri._direction,
+                                0,
+                                ri.wavelength,
+                                ri.n,
+                                ri.label,
+                                ri.draw_color,
+                                ri,
+                                ri.pop,
+                                self.id,
+                                0,
+                                ri._parent_cnt+1)
+
+        return [ret_ray]
+
+#    cpdef list propagate(self, Ray ri, double ni, double nr):
+#        """
+#        Determine whether a ray continues propagating after intersecting the surface.#
+#
+#        This method overrides `Surface.propagate` to decide if a ray should continue
+#        propagating or not after it intersects the surface. It checks if the
+#        intersection point lies within the aperture defined by `ap_shape`.
+#
+#        Parameters
+#        ----------
+#        ri : Ray
+#            The incoming ray to be propagated. This ray is in the coordinate system
+#            of the surface.
+#        ni : double
+#            The refractive index of the medium from which the ray is incoming.
+#            This parameter is not used in this implementation.
+#        nr : double
+#            The refractive index of the medium into which the ray would propagate.
+#            This parameter is not used in this implementation.
+#
+#        Returns
+#        -------
+#        list of Ray
+#            A list containing the resulting ray. The intensity of the ray is set to
+#            zero if the intersection point does not lie within the aperture, indicating
+#            that the ray does not continue propagating. Otherwise, the ray continues
+#            with its original intensity.
+#
+#        Warnings
+#        --------
+#        This surface only checks if the ray continues propagating or not based on
+#        the aperture shape. It does not calculate refraction or reflection.
+#        Therefore, it must not be used to model lenses or mirrors.
+#
+#        Notes
+#        -----
+#        - The method calculates the intersection point between the incoming ray
+#        and the surface and checks if this point is within the defined aperture.
+#        - If the intersection point is within the aperture, the ray continues
+#        propagating with its original intensity. If not, the ray's intensity
+#        is set to zero, effectively stopping its propagation.
+#        """
+#        # Calculate the intersection point and the surface normal
+#        cdef Vector3d PI
+#
+#        self._calculate_intersection(ri, PI)
+#
+#        # Check if the intersection point is within the aperture
+#        if self.ap_shape.hit_cy(PI):
+#            i = ri.intensity
+#        else:
+#            i = 0.
+#
+#        ret_ray = Ray.fast_init(PI,
+#                               ri._direction,
+#                                i,
+#                                ri.wavelength,
+#                                ri.n,
+#                                ri.label,
+#                                ri.draw_color,
+#                                ri,
+#                                ri.pop,
+#                                self.id,
+#                                0,
+#                                ri._parent_cnt+1)
+#
+#        return [ret_ray]
+
+    def __repr__(self):
+        """
+        Return a string representation of the OpticalStop surface.
+
+        This method provides a detailed string representation of the `OpticalStop`
+        object, including its shape, aperture shape, and other relevant attributes
+        inherited from the `Plane` class.
+
+        Returns
+        -------
+        str
+            A string that represents the current state of the `OpticalStop` object.
+        """
+        return (
+            f"OpticalStop(shape={repr(self.shape)}, "
+            f"ap_shape={repr(self.ap_shape)}, "
+            f"id={self.id})"
+        )
+
+
+def Aperture(*args, **kwargs):
+    """
+    Deprecated: Use OpticalStop instead.
+
+    This function provides backwards compatibility for existing code
+    using the Aperture class. It creates an OpticalStop instance and
+    emits a deprecation warning.
+
+    Parameters
+    ----------
+    *args, **kwargs
+        Arguments passed through to OpticalStop constructor.
+
+    Returns
+    -------
+    OpticalStop
+        An OpticalStop instance.
+
+    Warnings
+    --------
+    DeprecationWarning
+        Always emitted when this function is called.
+    """
+    import warnings
+    warnings.warn(
+        "Aperture is deprecated, use OpticalStop instead",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    return OpticalStop(*args, **kwargs)

--- a/pyoptools/raytrace/surface/plane.pyx
+++ b/pyoptools/raytrace/surface/plane.pyx
@@ -73,9 +73,22 @@ cdef class Plane(Surface):
         (<double*>(&normal(1)))[0] = 0.
         (<double*>(&normal(2)))[0] = 1.
 
-    def _repr_(self):
+    def __repr__(self):
         '''Return an string with the representation of the optical plane
         '''
+        attrs = []
 
-        return "Plane(shape="+str(self.shape)+",reflectivity=" + \
-            str(self.reflectivity)+")"
+        if self.shape is not None:
+            attrs.append(f"shape={self.shape!r}")
+
+        if self.reflectivity != 0:
+            attrs.append(f"reflectivity={self.reflectivity}")
+
+        # Include other Surface attributes if they exist
+        if hasattr(self, 'coating') and self.coating is not None:
+            attrs.append(f"coating={self.coating!r}")
+
+        if hasattr(self, 'material') and self.material is not None:
+            attrs.append(f"material={self.material!r}")
+
+        return f"Plane({', '.join(attrs)})"

--- a/pyoptools/raytrace/surface/simpledmd.pyx
+++ b/pyoptools/raytrace/surface/simpledmd.pyx
@@ -1,0 +1,249 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2007, Ricardo Amézquita Orozco
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the GPLv3
+# license included in LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.
+#
+#
+# Author:          Ricardo Amézquita Orozco
+# Description:     SimpleDMD surface definition module
+# Symbols Defined: SimpleDMD
+# ------------------------------------------------------------------------------
+
+'''Module that defines a simplified DMD (Digital Micromirror Device) surface class
+
+SimpleDMD models a DMD as a flat reflective surface with a state-dependent tilted
+normal vector. This is suitable for system-level optical design where pixel-level
+effects are negligible.
+'''
+
+from libc.math cimport sin, cos
+
+from pyoptools.raytrace.surface.plane cimport Plane
+from pyoptools.misc.cmisc.eigen cimport Vector3d
+
+
+cdef class SimpleDMD(Plane):
+    '''Simplified DMD surface with state-dependent tilted normal.
+
+    SimpleDMD represents a Digital Micromirror Device as a geometrically flat
+    surface (z=0 plane) with a tilted normal vector that depends on the DMD state.
+    This provides a computationally efficient model for system-level optical design
+    without modeling individual micromirrors.
+
+    The surface supports three states:
+    - "on": Normal tilted by tilt_angle in on_direction_angle
+    - "off": Normal tilted by tilt_angle in off_direction_angle
+    - "flat": Normal perpendicular to surface (0, 0, 1)
+
+    Parameters
+    ----------
+    tilt_angle : float
+        Tilt angle in radians. This is the angle between the surface normal and
+        the perpendicular direction (Z-axis). When tilt_angle=0, the normal is
+        perpendicular to the surface. Use math.radians() to convert from degrees.
+    on_direction_angle : float
+        Direction angle in radians defining where the surface normal is rotated
+        to for the ON state. Measured counter-clockwise from the +X axis in the
+        XY plane when viewed from +Z. For example, 0° points toward +X, 90° points
+        toward +Y, 180° points toward -X, and 270° points toward -Y.
+    off_direction_angle : float
+        Direction angle in radians defining where the surface normal is rotated
+        to for the OFF state. Measured counter-clockwise from the +X axis in the
+        XY plane when viewed from +Z. For example, 0° points toward +X, 90° points
+        toward +Y, 180° points toward -X, and 270° points toward -Y.
+    state : str, optional
+        Initial state: "on", "off", or "flat". Default is "flat".
+    shape : Shape
+        Aperture shape (e.g., Rectangular, Circular) defining the active area.
+    **kwargs
+        Additional arguments passed to Surface base class (except reflectivity,
+        which is hardcoded to 1.0).
+
+    Attributes
+    ----------
+    state : str
+        Current DMD state ("on", "off", or "flat"). Can be changed at runtime.
+
+    Notes
+    -----
+    - All angles are in radians (consistent with pyoptools conventions)
+    - The surface is always fully reflective (reflectivity = 1.0)
+    - Ray-surface intersection is geometrically flat (z=0 plane)
+    - Reflection uses the state-dependent tilted normal vector
+    - Normal vectors are pre-computed for performance and automatically normalized
+
+    The normal vector calculation uses spherical coordinates:
+        normal_x = sin(tilt_angle) * cos(direction_angle)
+        normal_y = sin(tilt_angle) * sin(direction_angle)
+        normal_z = cos(tilt_angle)
+
+    This is equivalent to rotating (0,0,1) using:
+        compute_rotation_matrix(Rx=0, Ry=tilt_angle, Rz=direction_angle)
+
+    Limitations
+    -----------
+    - This is a simplified model suitable for system-level design
+    - Does not model individual pixels, diffraction, or fill factor effects
+    - Surface is geometrically flat; only the optical normal is tilted
+    - For pixel-level accuracy, use PixelatedDMD (future implementation)
+
+    Examples
+    --------
+    >>> from math import radians
+    >>> from pyoptools.raytrace.surface import SimpleDMD
+    >>> from pyoptools.raytrace.shape import Rectangular
+    >>>
+    >>> # Create a DMD with 12° tilt magnitude
+    >>> # ON state: normal rotates 12° toward 45° direction (northeast)
+    >>> # OFF state: normal rotates 12° toward 225° direction (southwest)
+    >>> dmd = SimpleDMD(
+    ...     tilt_angle=radians(12),           # 12° tilt magnitude
+    ...     on_direction_angle=radians(45),   # Normal tilts toward northeast
+    ...     off_direction_angle=radians(225), # Normal tilts toward southwest
+    ...     state="on",
+    ...     shape=Rectangular(size=(10.8, 10.8))  # Mirror size in mm
+    ... )
+    >>>
+    >>> # Switch state at runtime
+    >>> dmd.state = "off"
+    >>> dmd.state = "flat"
+    '''
+
+    # C-level attributes for pre-computed normal vectors
+    cdef Vector3d _normal_on
+    cdef Vector3d _normal_off
+    cdef Vector3d _normal_flat
+    cdef str _state
+    cdef double _tilt_angle
+    cdef double _on_direction_angle
+    cdef double _off_direction_angle
+
+    def __init__(self,
+                 double tilt_angle,
+                 double on_direction_angle,
+                 double off_direction_angle,
+                 str state="flat",
+                 shape=None,
+                 **kwargs):
+        '''Initialize SimpleDMD surface.
+
+        Parameters defined in class docstring.
+        '''
+        # Store parameters for __repr__
+        self._tilt_angle = tilt_angle
+        self._on_direction_angle = on_direction_angle
+        self._off_direction_angle = off_direction_angle
+
+        # Validate state parameter
+        if state not in ("on", "off", "flat"):
+            raise ValueError(
+                f"Invalid state '{state}'. Must be 'on', 'off', or 'flat'."
+            )
+
+        # Remove reflectivity from kwargs if present (we hardcode it to 1.0)
+        kwargs.pop('reflectivity', None)
+
+        # Initialize parent Plane with reflectivity=1.0 (always reflective)
+        Plane.__init__(self, shape=shape, reflectivity=1.0, **kwargs)
+
+        # Pre-compute normal vectors for each state
+        # Using direct trigonometric formula (spherical coordinates)
+        # This is equivalent to:
+        # compute_rotation_matrix(Rx=0, Ry=tilt_angle, Rz=direction_angle) @ (0,0,1)
+
+        # ON state normal - use pointer syntax like in Plane
+        (<double*>(&self._normal_on(0)))[0] = sin(tilt_angle) * cos(on_direction_angle)
+        (<double*>(&self._normal_on(1)))[0] = sin(tilt_angle) * sin(on_direction_angle)
+        (<double*>(&self._normal_on(2)))[0] = cos(tilt_angle)
+        # Normalize to ensure unit length
+        self._normal_on.normalize()
+
+        # OFF state normal
+        (<double*>(&self._normal_off(0)))[0] = \
+            sin(tilt_angle) * cos(off_direction_angle)
+        (<double*>(&self._normal_off(1)))[0] = \
+            sin(tilt_angle) * sin(off_direction_angle)
+        (<double*>(&self._normal_off(2)))[0] = cos(tilt_angle)
+        # Normalize to ensure unit length
+        self._normal_off.normalize()
+
+        # FLAT state normal (perpendicular to surface)
+        (<double*>(&self._normal_flat(0)))[0] = 0.0
+        (<double*>(&self._normal_flat(1)))[0] = 0.0
+        (<double*>(&self._normal_flat(2)))[0] = 1.0
+        # Already unit length, but normalize for consistency
+        self._normal_flat.normalize()
+
+        # Set initial state
+        self._state = state
+
+    @property
+    def state(self):
+        '''Get current DMD state.
+
+        Returns
+        -------
+        str
+            Current state: "on", "off", or "flat"
+        '''
+        return self._state
+
+    @state.setter
+    def state(self, str value):
+        '''Set DMD state.
+
+        Parameters
+        ----------
+        value : str
+            New state: "on", "off", or "flat"
+
+        Raises
+        ------
+        ValueError
+            If value is not a valid state.
+        '''
+        if value not in ("on", "off", "flat"):
+            raise ValueError(
+                f"Invalid state '{value}'. Must be 'on', 'off', or 'flat'."
+            )
+        self._state = value
+
+    cdef void _calculate_normal(self,
+                                Vector3d& intersection_point,
+                                Vector3d& normal) noexcept nogil:
+        '''Calculate state-dependent surface normal.
+
+        Returns the pre-computed normal vector based on current state.
+
+        Parameters
+        ----------
+        intersection_point : Vector3d
+            Point on surface (not used, included for interface compatibility)
+        normal : Vector3d
+            Output parameter for the normal vector
+        '''
+        # Return appropriate pre-computed normal based on state
+        # Note: String comparison in nogil context - use simple if-else chain
+        if self._state == "on":
+            normal = self._normal_on
+        elif self._state == "off":
+            normal = self._normal_off
+        else:  # "flat"
+            normal = self._normal_flat
+
+    def __repr__(self):
+        '''Return string representation of SimpleDMD surface.
+
+        Returns
+        -------
+        str
+            String representation showing shape and current state
+        '''
+        return (f"SimpleDMD(shape={self.shape}, state='{self._state}', "
+                f"reflectivity={self.reflectivity}, "
+                f"tilt_angle={self._tilt_angle:.5f}, "
+                f"on_direction_angle={self._on_direction_angle:.5f}, "
+                f"off_direction_angle={self._off_direction_angle:.5f})")

--- a/pyoptools/raytrace/surface/surface.pxd
+++ b/pyoptools/raytrace/surface/surface.pxd
@@ -41,10 +41,12 @@ cdef class Surface(Picklable):
 
     # Cython method to calculate the surface intersection with a ray
     # To be used by pyoptools Cython functions and methods
-    # TODO: Check what needs to be done for this method to be nogil
     cdef void intersection_cy(self,
                               Ray incident_ray,
-                              Vector3d& intersection_point)  # noexcept nogil
+                              Vector3d& intersection_point) noexcept nogil
+    cdef void intersection_bidirectional_cy(self,
+                                            Ray incident_ray,
+                                            Vector3d& intersection_point) noexcept nogil
 
     # Cython method to calculate the normal at a given intersection point
     # To be used by pyoptools Cython functions and methods

--- a/pyoptools/raytrace/system/idealcomponent.pyx
+++ b/pyoptools/raytrace/system/idealcomponent.pyx
@@ -216,7 +216,7 @@ class IdealThickLens(System):
         assign_tuple_to_vector3d(P, p_cy)
         assign_tuple_to_vector3d(D, d_cy)
         R = ri.ch_coord_sys_f(p_cy, d_cy)
-        PI = C["S0"][0].intersection(R)
+        PI = C["S0"][0].intersection(R, True)
 
         # Generate the ray from E1 to H1
         direction = R.direction if E1[1][2] < H1[1][2] else -R.direction
@@ -236,7 +236,7 @@ class IdealThickLens(System):
         assign_tuple_to_vector3d(P, p_cy)
         assign_tuple_to_vector3d(D, d_cy)
         R = R_E1.ch_coord_sys_f(p_cy, d_cy)
-        PI = C["S0"][0].intersection(R)
+        PI = C["S0"][0].intersection(R, True)
 
         # Create the ray between H1 and H2
         direction = (0, 0, 1) if H1[1][2] < H2[1][2] else (0, 0, -1)
@@ -250,7 +250,7 @@ class IdealThickLens(System):
         assign_tuple_to_vector3d(D, d_cy)
 
         R = R_H1.ch_coord_sys_f(p_cy, d_cy)
-        PI = C["S0"][0].intersection(R)
+        PI = C["S0"][0].intersection(R, True)
 
         # Calculate the refraction at H2
         _rx, _ry, rz = ri.direction
@@ -273,7 +273,7 @@ class IdealThickLens(System):
         assign_tuple_to_vector3d(P, p_cy)
         assign_tuple_to_vector3d(D, d_cy)
         R = R_H2.ch_coord_sys_f(p_cy, d_cy)
-        PI = C["S0"][0].intersection(R)
+        PI = C["S0"][0].intersection(R, True)
 
         # Check the exit aperture
         PE2 = not isnan(PI[0])
@@ -282,7 +282,7 @@ class IdealThickLens(System):
         if P2:
             C0, _P0, _D0 = P2
             R = R_H2.ch_coord_sys_f(p_cy, d_cy)
-            PII = C0["S0"][0].intersection(R)
+            PII = C0["S0"][0].intersection(R, True)
             ST2 = not (isnan(PII[0]) or isnan(PII[1]) or isnan(PII[2]))
         else:  # No exit pupil check
             ST2 = True
@@ -330,7 +330,8 @@ class IdealThickLens(System):
         min_pi = None
         min_surf = None
 
-        for comp in [self.complist["E1"], self.complist["E2"]]:
+        for reference in ["E1", "E2"]:
+            comp = self.complist[reference]
             C, P, D = comp
             # Reorient the ray to the coordinate system of the element
             # and calculate the ray's path until it intersects with the element
@@ -343,5 +344,4 @@ class IdealThickLens(System):
                 min_dist = Dist[0]
                 min_pi = Dist[1]
                 min_surf = Dist[2]
-
         return min_dist, min_pi, min_surf

--- a/tests/raytrace/surface/test_simpledmd.py
+++ b/tests/raytrace/surface/test_simpledmd.py
@@ -1,0 +1,312 @@
+"""Minimal test suite for SimpleDMD surface."""
+
+from math import radians, isclose, sqrt, pi
+import pytest
+
+from pyoptools.raytrace.surface.simpledmd import SimpleDMD
+from pyoptools.raytrace.shape.rectangular import Rectangular
+from pyoptools.raytrace.shape.circular import Circular
+from pyoptools.raytrace.ray.ray import Ray
+
+
+# ============================================================================
+# Section 1: Instantiation and Basic Validation
+# ============================================================================
+
+
+def test_simpledmd_instantiation():
+    """Test SimpleDMD can be instantiated with all parameters."""
+    dmd = SimpleDMD(
+        tilt_angle=radians(12),
+        on_direction_angle=radians(45),
+        off_direction_angle=radians(225),
+        state="on",
+        shape=Rectangular(size=(10, 10)),
+    )
+    assert dmd.state == "on"
+    assert dmd.shape is not None
+
+
+def test_simpledmd_default_state():
+    """Test SimpleDMD defaults to 'flat' state."""
+    dmd = SimpleDMD(
+        tilt_angle=radians(12),
+        on_direction_angle=radians(0),
+        off_direction_angle=radians(180),
+    )
+    assert dmd.state == "flat"
+
+
+def test_simpledmd_invalid_state():
+    """Test SimpleDMD rejects invalid state values."""
+    with pytest.raises(ValueError):
+        SimpleDMD(
+            tilt_angle=radians(12),
+            on_direction_angle=radians(0),
+            off_direction_angle=radians(180),
+            state="invalid",
+        )
+
+
+# ============================================================================
+# Section 2: State Transitions
+# ============================================================================
+
+
+def test_simpledmd_state_transitions():
+    """Test state can be changed between valid values."""
+    dmd = SimpleDMD(
+        tilt_angle=radians(12),
+        on_direction_angle=radians(0),
+        off_direction_angle=radians(180),
+        state="flat",
+    )
+
+    dmd.state = "on"
+    assert dmd.state == "on"
+
+    dmd.state = "off"
+    assert dmd.state == "off"
+
+    dmd.state = "flat"
+    assert dmd.state == "flat"
+
+
+def test_simpledmd_invalid_state_transition():
+    """Test setting invalid state raises ValueError."""
+    dmd = SimpleDMD(
+        tilt_angle=radians(12),
+        on_direction_angle=radians(0),
+        off_direction_angle=radians(180),
+    )
+
+    with pytest.raises(ValueError):
+        dmd.state = "broken"
+
+
+# ============================================================================
+# Section 3: Normal Vector Calculations
+# ============================================================================
+
+
+def test_simpledmd_cardinal_directions_normals():
+    """
+    For tilt=30°, test (on/off) direction angles of 0, 90, 180, 270 deg:
+    - At each position, normal should match precomputed, fixed expected values (regression, not math test)
+    """
+    from math import radians, isclose
+
+    tilt_deg = 30
+    tilt = radians(tilt_deg)
+    angles_deg = [0, 90, 180, 270]
+    angles_rad = [radians(deg) for deg in angles_deg]
+
+    # Precomputed normals for 30 degree tilt at four cardinal directions
+    expected_normals = [
+        (0.5, 0.0, 0.86602540378),  # 0 degrees
+        (0.0, 0.5, 0.86602540378),  # 90 degrees
+        (-0.5, 0.0, 0.86602540378),  # 180 degrees
+        (0.0, -0.5, 0.86602540378),  # 270 degrees
+    ]
+
+    # ON state: check returned normal matches fixed values
+    for i, on_dir in enumerate(angles_rad):
+        dmd = SimpleDMD(
+            tilt_angle=tilt,
+            on_direction_angle=on_dir,
+            off_direction_angle=angles_rad[(i + 2) % 4],  # Opposite dir
+            state="on",
+        )
+        normal = dmd.normal((0, 0, 0))
+        expected = expected_normals[i]
+        for j, comp in enumerate(["x", "y", "z"]):
+            assert isclose(normal[j], expected[j], abs_tol=1e-8), (
+                f"ON dir angle {angles_deg[i]}°: {comp} = {normal[j]} (expected {expected[j]})"
+            )
+        # Only one component (x or y) should be nonzero (or both approximately zero)
+        assert isclose(normal[0] * normal[1], 0.0, abs_tol=1e-9)
+
+    # OFF state: same normals but for off_direction_angle
+    for i, off_dir in enumerate(angles_rad):
+        dmd = SimpleDMD(
+            tilt_angle=tilt,
+            on_direction_angle=angles_rad[(i + 2) % 4],
+            off_direction_angle=off_dir,
+            state="off",
+        )
+        normal = dmd.normal((0, 0, 0))
+        expected = expected_normals[i]
+        for j, comp in enumerate(["x", "y", "z"]):
+            assert isclose(normal[j], expected[j], abs_tol=1e-8), (
+                f"OFF dir angle {angles_deg[i]}°: {comp} = {normal[j]} (expected {expected[j]})"
+            )
+        assert isclose(normal[0] * normal[1], 0.0, abs_tol=1e-9)
+
+
+def test_simpledmd_flat_state_normal():
+    """Test flat state produces perpendicular normal (0, 0, 1)."""
+    dmd = SimpleDMD(
+        tilt_angle=radians(12),
+        on_direction_angle=radians(45),
+        off_direction_angle=radians(225),
+        state="flat",
+    )
+
+    # Get normal at origin
+    normal = dmd.normal((0, 0, 0))
+
+    # Should be perpendicular regardless of tilt_angle
+    assert isclose(normal[0], 0.0, abs_tol=1e-9)
+    assert isclose(normal[1], 0.0, abs_tol=1e-9)
+    assert isclose(normal[2], 1.0, abs_tol=1e-9)
+
+
+def test_simpledmd_on_state_normal():
+    """Test on state produces correctly tilted normal."""
+    tilt = radians(12)
+    direction = radians(0)  # Along +X axis
+
+    dmd = SimpleDMD(
+        tilt_angle=tilt,
+        on_direction_angle=direction,
+        off_direction_angle=radians(180),
+        state="on",
+    )
+
+    normal = dmd.normal((0, 0, 0))
+
+    # Expected normal for tilt along +X axis
+    from math import sin, cos
+
+    expected_x = sin(tilt) * cos(direction)
+    expected_y = sin(tilt) * sin(direction)
+    expected_z = cos(tilt)
+
+    assert isclose(normal[0], expected_x, abs_tol=1e-9)
+    assert isclose(normal[1], expected_y, abs_tol=1e-9)
+    assert isclose(normal[2], expected_z, abs_tol=1e-9)
+
+    # Verify unit length
+    length = sqrt(normal[0] ** 2 + normal[1] ** 2 + normal[2] ** 2)
+    assert isclose(length, 1.0, abs_tol=1e-9)
+
+
+def test_simpledmd_off_state_normal():
+    """Test off state produces correctly tilted normal in opposite direction."""
+    tilt = radians(12)
+    on_dir = radians(45)
+    off_dir = radians(225)  # Opposite of 45°
+
+    dmd = SimpleDMD(
+        tilt_angle=tilt,
+        on_direction_angle=on_dir,
+        off_direction_angle=off_dir,
+        state="off",
+    )
+
+    normal = dmd.normal((0, 0, 0))
+
+    # Expected normal
+    from math import sin, cos
+
+    expected_x = sin(tilt) * cos(off_dir)
+    expected_y = sin(tilt) * sin(off_dir)
+    expected_z = cos(tilt)
+
+    assert isclose(normal[0], expected_x, abs_tol=1e-9)
+    assert isclose(normal[1], expected_y, abs_tol=1e-9)
+    assert isclose(normal[2], expected_z, abs_tol=1e-9)
+
+    # Verify unit length
+    length = sqrt(normal[0] ** 2 + normal[1] ** 2 + normal[2] ** 2)
+    assert isclose(length, 1.0, abs_tol=1e-9)
+
+
+# ============================================================================
+# Section 4: Ray Reflection (Basic Verification)
+# ============================================================================
+
+
+def test_simpledmd_reflects_ray_in_flat_state():
+    """Test that a ray reflects off SimpleDMD in flat state (normal incidence)."""
+    dmd = SimpleDMD(
+        tilt_angle=radians(12),
+        on_direction_angle=radians(0),
+        off_direction_angle=radians(180),
+        state="flat",
+        shape=Circular(radius=10),
+    )
+
+    # Ray traveling in -Z direction (toward surface at Z=0)
+    ray = Ray(origin=(0, 0, 5), direction=(0, 0, -1))
+
+    # Find intersection
+    intersection = dmd.intersection(ray)
+
+    # Should intersect at Z=0
+    assert isclose(intersection[0], 0.0, abs_tol=1e-6)
+    assert isclose(intersection[1], 0.0, abs_tol=1e-6)
+    assert isclose(intersection[2], 0.0, abs_tol=1e-6)
+
+    # Propagate ray to surface
+    # Get reflected ray (passing a plausible refractive index - only reflection should occur)
+    reflected_rays = dmd.propagate(ray, 1.0, 1.0)  # Reflection only
+
+    # Should have exactly one reflected ray
+    assert len(reflected_rays) == 1
+
+
+def test_simpledmd_normal_changes_with_state():
+    """Test that normal vector changes when state changes."""
+    dmd = SimpleDMD(
+        tilt_angle=radians(12),
+        on_direction_angle=radians(0),
+        off_direction_angle=radians(180),
+        state="flat",
+    )
+
+    normal_flat = dmd.normal((0, 0, 0))
+
+    dmd.state = "on"
+    normal_on = dmd.normal((0, 0, 0))
+
+    dmd.state = "off"
+    normal_off = dmd.normal((0, 0, 0))
+
+    # All three should be different
+    assert not (
+        isclose(normal_flat[0], normal_on[0], abs_tol=1e-9)
+        and isclose(normal_flat[1], normal_on[1], abs_tol=1e-9)
+        and isclose(normal_flat[2], normal_on[2], abs_tol=1e-9)
+    )
+
+    assert not (
+        isclose(normal_on[0], normal_off[0], abs_tol=1e-9)
+        and isclose(normal_on[1], normal_off[1], abs_tol=1e-9)
+        and isclose(normal_on[2], normal_off[2], abs_tol=1e-9)
+    )
+
+
+# ============================================================================
+# Section 5: Representation
+# ============================================================================
+
+
+def test_simpledmd_repr():
+    """Test SimpleDMD __repr__ returns expected format."""
+    dmd = SimpleDMD(
+        tilt_angle=radians(12),
+        on_direction_angle=radians(45),
+        off_direction_angle=radians(225),
+        state="on",
+        shape=Rectangular(size=(10, 10)),
+    )
+
+    repr_str = repr(dmd)
+
+    # Should contain class name and key parameters
+    assert "SimpleDMD" in repr_str
+    assert "state='on'" in repr_str
+    assert "tilt_angle" in repr_str
+    assert "on_direction_angle" in repr_str
+    assert "off_direction_angle" in repr_str


### PR DESCRIPTION
- Replaced Aperture with OpticalStop in stop.py to enhance clarity and functionality.
- Updated comp_lib.py to include SimpleDMDDevice in the module exports.
- Modified surface __init__.py to import OpticalStop and SimpleDMD, ensuring proper module structure.
- Introduced opticalstop.pyx to define the OpticalStop class, encapsulating the functionality of optical stops.
- Created simpledmd.pyx to implement the SimpleDMD surface class, modeling a Digital Micromirror Device.
- Enhanced plane.pyx to improve the __repr__ method for better debugging and logging.
- Added tests for SimpleDMD surface to validate instantiation, state transitions, normal vector calculations, and ray reflection behavior.
- Updated intersection methods in surface.pyx to support bidirectional ray tracing.